### PR TITLE
add region codes for greece, scotland, taiwan, and south korea

### DIFF
--- a/spectrum/autism_prevalence_map/management/commands/pull_studies_from_gsheets.py
+++ b/spectrum/autism_prevalence_map/management/commands/pull_studies_from_gsheets.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
                 area = ''
             address = '?address=' + urllib.parse.quote(area) + ',' + urllib.parse.quote(country)
             #add region codes for the countries that are being located wrongly by google geocode API
-            countrymap = {'Japan': 'jp', 'Qatar': 'qa', 'Iran': 'ir'};
+            countrymap = {'Japan': 'jp', 'Qatar': 'qa', 'Iran': 'ir', 'Greece': 'gr', 'Scotland': 'gb', 'Taiwan': 'tw', 'South Korea': 'kr'};
             if country in countrymap.keys() :
                 address = address + '&region=' + countrymap[country]
             url = base_url + address + gmaps_api_key


### PR DESCRIPTION
This PR is to plot Greece, Scotland, Taiwan, and South Korea correctly.

- [x] Check out this branch and run pull_studies_from_gsheets.py.
- [x] Go to http://127.0.0.1:8000/ and look for Hong et al. 2020, Rydzewska et al. 2019, Lai et al. 2012, and Thomaidis et al. 2020 and see that they are mapped in the respective countries.