### PR TITLE
Jinfeng/specwww 724: Fix overlapping text and remove newsletter sub field for Global Autism Prevalence Map

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -1,22 +1,21 @@
-{% extends 'autism_prevalence_map/base.html' %} 
+{% extends 'autism_prevalence_map/base.html' %}
 
-{% load staticfiles %} 
+{% load staticfiles %}
 
-{% block title %}Spectrum | Global Autism Prevalence Map{% endblock %} 
+{% block title %}Spectrum | Global Autism Prevalence Map{% endblock %}
 
 {% block css_block %}
 <!-- Custom map CSS
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<link rel='stylesheet' id='main-stylesheet-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/style.css?ver=2.0.2' type='text/css' media='all' />
-<link rel='stylesheet' id='spectrum-style-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/css/spectrum.min.css?ver=2.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='spectrum-style-css'  href={{css_base|add:'/wp-content/themes/sfari-spectrum/css/spectrum.min.css?ver=2.0.2'}} type='text/css' media='all' />
 <link rel="stylesheet" type="text/css" href="{% static 'autism_prevalence_map/css/about.css' %}">
-{% endblock %} 
+{% endblock %}
 
 
 {% block body_block %}
 <!-- Main Container
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<section class="hero-nav container orange">
+<section class="hero-nav container orange page-template-page-about">
     <div class="sidebar-container container">
         <div class="row">
             <aside class="col-3 sidebar">
@@ -62,12 +61,12 @@
 
 {% endblock %}
 
-{% block modal_block %} 
-{% endblock %} 
+{% block modal_block %}
+{% endblock %}
 
 {% block js_block %}
 <!-- Custom JS
-–––––––––––––––––––––––––––––––––––––––––––––––––– -->   
+–––––––––––––––––––––––––––––––––––––––––––––––––– -->
 <script src="{% static 'autism_prevalence_map/js/about.js' %}"></script>
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 {% endblock %}

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -20,7 +20,7 @@
     <div class="sidebar-container container">
         <div class="row">
             <aside class="col-3 sidebar">
-                <ul class="chapter-navigation">
+                <ul class="chapter-navigation prevalence-map-about">
                     <li class="chapter-link"><a href="#1" class="active">About the map<div class="progress background" style="height: 62.9278%; width: 5px;"></div></a></li>
                     <li class="chapter-link"><a href="#2">How to use the map<div class="progress background" style="height: 0%; width: 5px;"></div></a></li>
                     <li class="chapter-link"><a href="#3">How to cite the map<div class="progress background" style="height: 0%; width: 5px;"></div></a></li>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -15,11 +15,11 @@
 {% block body_block %}
 <!-- Main Container
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<section class="hero-nav container orange page-template-page-about">
-    <div class="sidebar-container container">
+<section class="hero-nav container orange" id="prevalence-map-about">
+    <div class="sidebar-container container " >
         <div class="row">
             <aside class="col-3 sidebar">
-                <ul class="chapter-navigation prevalence-map-about">
+                <ul class="chapter-navigation ">
                     <li class="chapter-link"><a href="#1" class="active">About the map<div class="progress background" style="height: 62.9278%; width: 5px;"></div></a></li>
                     <li class="chapter-link"><a href="#2">How to use the map<div class="progress background" style="height: 0%; width: 5px;"></div></a></li>
                     <li class="chapter-link"><a href="#3">How to cite the map<div class="progress background" style="height: 0%; width: 5px;"></div></a></li>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -7,8 +7,8 @@
 {% block css_block %}
 <!-- Custom map CSS
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<link rel='stylesheet' id='main-stylesheet-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/style.css?ver=1.1.3' type='text/css' media='all' />
-<link rel='stylesheet' id='spectrum-style-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/css/spectrum.css?ver=1.1.3' type='text/css' media='all' />
+<link rel='stylesheet' id='main-stylesheet-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/style.css?ver=2.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='spectrum-style-css'  href='https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/css/spectrum.min.css?ver=2.0.2' type='text/css' media='all' />
 <link rel="stylesheet" type="text/css" href="{% static 'autism_prevalence_map/css/about.css' %}">
 {% endblock %} 
 

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.shortcuts import render
 from django.http import JsonResponse, HttpResponse
+import os
 from datetime import date
 import re, csv
 from django.contrib.postgres.search import SearchVector, SearchQuery
@@ -63,7 +64,15 @@ def about(request):
 	"""
 	  About page
 	"""
-	context_dict = {}
+	if os.environ["DJANGO_ALLOWED_HOSTS"] == 'prevalence-staging.spectrumnews.org' :
+		css_base = 'https://staging.spectrumnews.org'
+	elif os.environ["DJANGO_ALLOWED_HOSTS"] == '127.0.0.1' :
+		css_base = 'http://dev.spectrum.test:8010'
+	else :
+		css_base = 'https://www.spectrumnews.org'
+	context_dict = {
+		'css_base' : css_base,
+	}
 	return render(request, 'autism_prevalence_map/about.html', context_dict)
 
 


### PR DESCRIPTION
jira ticket: [SPECWWW-724](https://simonsfoundation.atlassian.net/browse/SPECWWW-724)

- [x] Finish steps [here](https://github.com/simonsfoundation/spectrum/pull/536) if not
- [x] Check out this branch.
- [x] Change temporarily code as shown on the screenshot
<img width="2512" alt="Screen Shot 2022-07-05 at 10 53 09 AM" src="https://user-images.githubusercontent.com/9726273/177356882-0dc3f2c7-ac13-4857-8365-9d502f4719db.png">

- [x] Run command `python manage.py runserver`

- [x] Access http://127.0.0.1:8000/about/ and confirm now the navigation appears and works well as shown on the following screenshot.
<img width="2512" alt="Screen Shot 2022-07-05 at 10 58 05 AM" src="https://user-images.githubusercontent.com/9726273/177357735-7f28eff6-747a-4359-b40a-a69baea84951.png">
