### PR TITLE
specwww-756-r: install honey pot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ wrapt==1.10.11
 uWSGI==2.0.19.1
 django-admin-ip-restrictor==2.2.0
 django-ipware==3.0.7
+django-admin-honeypot==1.1.0

--- a/spectrum/spectrum/settings.py
+++ b/spectrum/spectrum/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.postgres',
+    'admin_honeypot',
 ]
 
 MIDDLEWARE = [

--- a/spectrum/spectrum/urls.py
+++ b/spectrum/spectrum/urls.py
@@ -17,6 +17,7 @@ from django.conf.urls import url, include
 from django.contrib import admin
 
 urlpatterns = [
+    url(r'^admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
     url(r'^submarine/', admin.site.urls),
     url(r'^', include('autism_prevalence_map.urls')),
 ]


### PR DESCRIPTION
Jira ticket: [SPECWWW-756](https://simonsfoundation.atlassian.net/browse/SPECWWW-756)

Note: This PR is for installing honey pot for admin path at the backend

To test:

- [ ] Check out this branch
- [ ] Run command `pip install -r requirement.txt` in the project root directory
- [ ] Run command `python manage.py migrate` in project root directory
- [ ] Run command `python manage.py runserver` in project root directory
- [ ] Access http://127.0.0.1:8000/admin and confirm you can put in credentials but cannot log in even they are correct.
- [ ] Access http://127.0.0.1:8000/submarine/ and confirm you can login on this page.