### PR TITLE
specwww 767/770: Add bulk import functionality to prevalence map backend panel/Improved download functionality for prevalence map

### DIFF
--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -5,6 +5,8 @@ import sys, os, urllib.request, json, time, datetime, re
 from django.contrib import admin
 from .models import studies
 from django import forms
+from django.conf.urls import url
+from django.template.response import TemplateResponse
 class StudiesForm(forms.ModelForm):
     
     yearpublished = forms.CharField(label='Year Published', required=False, initial='')
@@ -66,6 +68,21 @@ class StudiesAdmin(admin.ModelAdmin):
                      )
     form = StudiesForm
 
+    def get_urls(self):
+        urls = super().get_urls()
+        bulk_import_urls = [
+            url(r'bulk-import/', self.bulk_import_vew),
+        ]
+        return bulk_import_urls + urls
+
+    def bulk_import_vew(self, request):
+        context = dict(
+           # Include common variables for rendering the admin template.
+           self.admin_site.each_context(request),
+           # Anything else you want in the context...
+        )
+        return TemplateResponse(request, "admin/bulk_import.html", context)
+        
     def save_model(self, request, obj, form, change):
         self.parse_data(obj)
         self.geocode(obj)

--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -83,9 +83,60 @@ class StudiesAdmin(admin.ModelAdmin):
         if request.method == 'POST':
             #import data to database here
             with io.TextIOWrapper(request.FILES["csv_file"], encoding="utf-8", newline='\n') as text_file:
-                reader = csv.reader(text_file)
+                reader = csv.DictReader(text_file)
                 for row in reader:
-                    print(row)
+                    try:
+                        #skip if year not a date
+                        print(row)
+                        yearpublished = row['Year published']
+
+                        if yearpublished:
+                            try:
+                                yearpublished_number = datetime.datetime.strptime(yearpublished, '%Y')
+                            except ValueError:
+                                yearpublished_number = None
+                        else:
+                            yearpublished_number = None
+
+                        if yearpublished_number:
+
+                            #use get or create to only create records for objects newly added to the spreadsheets
+                            updated_values = {
+                                'yearpublished': row['Year published'] if row['Year published'] is not None else '',
+                                'authors': row['Authors'] if row['Authors'] is not None else '', 
+                                'country': row['Country'] if row['Country'] is not None else '', 
+                                'area': row['Area'] if row['Area'] is not None else '', 
+                                'samplesize': row['Sample size'] if row['Sample size'] is not None else '', 
+                                'age': row['Age (years)'] if row['Age (years)'] is not None else '', 
+                                'individualswithautism': row['Individuals with autism'] if row['Individuals with autism'] is not None else '', 
+                                'diagnosticcriteria': row['Diagnostic criteria'] if row['Diagnostic criteria'] is not None else '', 
+                                'diagnostictools': row['Diagnostic tools'] if row['Diagnostic tools'] is not None else '', 
+                                'percentwaverageiq': row['Percent w/ average IQ'] if row['Percent w/ average IQ'] is not None else '', 
+                                'sexratiomf': row['Sex ratio (M:F)'] if row['Sex ratio (M:F)'] is not None else '', 
+                                'prevalenceper10000': row['Prevalence (per 10,000)'] if row['Prevalence (per 10,000)'] is not None else '', 
+                                'confidenceinterval': row['95% Confidence interval'] if row['95% Confidence interval'] is not None else '', 
+                                'categoryadpddorasd': row['Category (AD, PDD or ASD)'] if row['Category (AD, PDD or ASD)'] is not None else '',
+                                'yearsstudied': row['Year(s) studied'] if row['Year(s) studied'] is not None else '',
+                                'recommended': row['Recommended'] if row['Recommended'] is not None else '', 
+                                'studytype': row['Study type'] if row['Study type'] is not None else '',
+                                'meanincomeofparticipants': row['Mean income of participants'] if row['Mean income of participants'] is not None else '',
+                                'educationlevelofparticipants': row['Education level of participants'] if row['Education level of participants'] is not None else '',
+                                'citation': row['Citation'] if row['Citation'] is not None else '',
+                                'link1title': row['Link 1 Title'] if row['Link 1 Title'] is not None else '',
+                                'link1url': row['Link 1 URL'] if row['Link 1 URL'] is not None else '',
+                                'link2title': row['Link 2 Title'] if row['Link 2 Title'] is not None else '',
+                                'link2url': row['Link 2 URL'] if row['Link 2 URL'] is not None else '',
+                                'link3title': row['Link 3 Title'] if row['Link 3 Title'] is not None else '',
+                                'link3url': row['Link 3 URL'] if row['Link 3 URL'] is not None else '',
+                                'link4title': row['Link 4 Title'] if row['Link 4 Title'] is not None else '',
+                                'link4url': row['Link 4 URL'] if row['Link 4 URL'] is not None else ''
+                            }
+                            obj, created = studies.objects.update_or_create(gsheet_id=index, defaults=updated_values)
+
+                    except Exception as e:
+                        # if error
+                        print('load research data error')
+                        print(e)
             
             #...
             self.message_user(request, "Your csv file has been imported")

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/bulk_import.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/bulk_import.html
@@ -1,1 +1,15 @@
-<h1>Bulk import succeeded</h1>
+
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_list %}
+{% block content %}
+    <div>
+        <form action="." method="POST" enctype="multipart/form-data">
+            {{ form.as_p }}
+            {% csrf_token %}
+
+                <button type="submit">Upload CSV</button>
+        </form>
+    </div>
+    <br />
+
+{% endblock %}

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/bulk_import.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/bulk_import.html
@@ -1,0 +1,1 @@
+<h1>Bulk import succeeded</h1>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/change_list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/change_list.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static admin_list %}
+{% block object-tools-items %}
+    {% if has_add_permission %}
+    <li>
+        <a href="bulk-import/">Bulk Importer</a>
+    </li>
+    <li>
+        {% url cl.opts|admin_urlname:'add' as add_url %}
+        <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
+        {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
+        </a>
+    </li>
+    {% endif %}
+{% endblock %}

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/change_list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/admin/change_list.html
@@ -3,7 +3,7 @@
 {% block object-tools-items %}
     {% if has_add_permission %}
     <li>
-        <a href="bulk-import/">Bulk Importer</a>
+        <a href="bulk-import/">Bulk Import</a>
     </li>
     <li>
         {% url cl.opts|admin_urlname:'add' as add_url %}

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -401,11 +401,19 @@ def studiesCsv(request):
 		writer = csv.writer(response)
 
 		# CSV header
-		writer.writerow(['Year published', 'Authors', 'Country', 'Area', 'Sample size', 'Age (years)', 'Individuals with autism', 'Diagnostic criteria', 'Diagnostic tools', 'Percent w/ average IQ', 'Sex ratio (M:F)', 'Prevalence (per 10,000)', '95% Confidence interval', 'Category (AD, PDD or ASD)', 'Year(s) studied', 'Recommended', 'Study type', 'Mean income of participants', 'Education level of participants', 'Citation', 'Link 1 Title', 'Link 1 URL', 'Link 2 Title', 'Link 2 URL', 'Link 3 Title', 'Link 3 URL', 'Link 4 Title', 'Link 4 URL'])
-
+		writer.writerow(['Year published', 'Authors', 'Country', 'Area', 'Sample size', 'Age (years)', 
+        'Individuals with autism', 'Diagnostic criteria', 'Diagnostic tools', 'Percent w/ average IQ', 
+        'Sex ratio (M:F)', 'Prevalence (per 10,000)', '95% Confidence interval', 'Category (AD, PDD or ASD)', 
+        'Year(s) studied', 'Recommended', 'Study type', 'Mean income of participants', 'Education level of participants', 
+        'Citation', 'Link 1 Title', 'Link 1 URL', 'Link 2 Title', 'Link 2 URL', 'Link 3 Title', 'Link 3 URL', 'Link 4 Title', 
+        'Link 4 URL'])
 
 		for study in pulled_studies:
-			writer.writerow([study.yearpublished.encode('utf8'), study.authors.encode('utf8'), study.country.encode('utf8'), study.area.encode('utf8'), study.samplesize.encode('utf8'), study.age.encode('utf8'), study.individualswithautism.encode('utf8'), study.diagnosticcriteria.encode('utf8'), study.diagnostictools.encode('utf8'), study.percentwaverageiq.encode('utf8'), study.sexratiomf.encode('utf8'), study.prevalenceper10000.encode('utf8'), study.confidenceinterval.encode('utf8'), study.categoryadpddorasd.encode('utf8'), study.yearsstudied.encode('utf8'), study.recommended.encode('utf8'), study.studytype.encode('utf8'), study.meanincomeofparticipants.encode('utf8'), study.educationlevelofparticipants.encode('utf8'), study.citation.encode('utf8'), study.link1title.encode('utf8'),  study.link1url.encode('utf8'), study.link2title.encode('utf8'),  study.link2url.encode('utf8'), study.link3title.encode('utf8'),  study.link3url.encode('utf8'), study.link4title.encode('utf8'),  study.link4url.encode('utf8')])
+			writer.writerow([study.yearpublished, study.authors, study.country, study.area, study.samplesize, study.age, 
+            study.individualswithautism, study.diagnosticcriteria, study.diagnostictools, study.percentwaverageiq, study.sexratiomf, 
+            study.prevalenceper10000, study.confidenceinterval, study.categoryadpddorasd, study.yearsstudied, study.recommended, 
+            study.studytype, study.meanincomeofparticipants, study.educationlevelofparticipants, study.citation, study.link1title,  
+            study.link1url, study.link2title,  study.link2url, study.link3title,  study.link3url, study.link4title,  study.link4url])
 
 		response['status'] = "200"
 

--- a/spectrum/spectrum/settings.py
+++ b/spectrum/spectrum/settings.py
@@ -59,11 +59,10 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'spectrum.urls'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'autism_prevalence_map', 'templates', 'autism_prevalence_map')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
Jira ticket: [SPECWWW-770](https://simonsfoundation.atlassian.net/browse/SPECWWW-770), [SPECWWW-767](https://simonsfoundation.atlassian.net/browse/SPECWWW-767)

To test:

- [x] Check out this branch
- [x] Run command `python manage.py runserver` under directory "spectrum-autism-prevalence-map/spectrum"
- [x] Access http://127.0.0.1:8000/, click on the download icon on the top right corner of the page to export CSV data to a file, and confirm it works well and the file contains well formatted data.
- [x] Edit the downloaded file to remove some lines and modify some content.
- [x] Access the backend admin http://127.0.0.1:8000/submarine/autism_prevalence_map/studies/, and click on the "bulk import" button on the top right part of the page, and select the modified file during the following steps, and upload it.
- [x] After the backend page refreshes, confirm the data displayed reflects the changes you have done.