### PR TITLE
specwww 818: Geo Info not Retrievable for Some Country Area Combinations

### DIFF
--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -162,6 +162,9 @@ class StudiesAdmin(admin.ModelAdmin):
     
         if area in ('Mainland and Azores', 'Northern Ostrobothnia County', 'Nationwide'):
             area = ''
+        if area == 'Middlesex':
+            country = 'London'
+            
         address = '?address=' + urllib.parse.quote(area) + ',' + urllib.parse.quote(country)
         #add region codes for the countries/areas that are being located wrongly by google geocode API
         countrymap = {'Japan': 'jp', 'Qatar': 'qa',

--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -157,13 +157,13 @@ class StudiesAdmin(admin.ModelAdmin):
         area = study.area
         country = study.country
 
-        if not area or not country:
+        if not country:
             return None 
     
-        if area in ('Mainland and Azores', 'Northern Ostrobothnia County') :
+        if area in ('Mainland and Azores', 'Northern Ostrobothnia County', 'Nationwide'):
             area = ''
         address = '?address=' + urllib.parse.quote(area) + ',' + urllib.parse.quote(country)
-        #add region codes for the countries that are being located wrongly by google geocode API
+        #add region codes for the countries/areas that are being located wrongly by google geocode API
         countrymap = {'Japan': 'jp', 'Qatar': 'qa',
                       'Iran': 'ir', 'Greece': 'gr',
                       'Scotland': 'gb', 'Taiwan': 'tw',
@@ -184,7 +184,6 @@ class StudiesAdmin(admin.ModelAdmin):
             longitude = None
         study.latitude=latitude
         study.longitude=longitude
-        time.sleep(1)
 
     def parse_data(self, study):
         # for year, population, and prevalence rate, convert from strings to dates and numbers and store in DB


### PR DESCRIPTION
Jira ticket: [SPECWWW-818](https://simonsfoundation.atlassian.net/browse/SPECWWW-818)

To test:

- [x] Run command `python manage.py runserver `to start the development server.
- [x] Access page http://127.0.0.1:8000/submarine/ and click button "Bulk Import" to import data.(the csv file is attached to the ticket in Jira)
- [x] Confirm that there are rows that don't have longitude and latitude values.
- [x] Check out this branch
- [x] Refresh the above page and upload the file again.
- [x] Confirm now every row has full longitude and latitude values.