### PR TITLE
specwww 866： Hide "income" and "education" columns from front-end of Prev Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ If you don’t have postgresql,
 Create an empty db in postgres.
 `createdb prevalence`
 
+add GMAP_API_KEY(the actual value is in team's doc) to file .env like the following.
+```
+GMAP_API_KEY='ddN3i59_QccZTqB4cWGy'
+```
+
 Add your postgres db info into .env. The following is an example.
 
 ```
+
 DB_HOST='localhost'
 
 DB_NAME='prevalence'
@@ -55,7 +61,7 @@ First change models.py and then run `python manage.py makemigrations` to automat
 
 Run `python manage.py dbshell`.
 
-3. If you want to access the backend admin site on http://127.0.0.1:8000/admin/ but without a user
+3. If you want to access the backend admin site on http://127.0.0.1:8000/submarine/ but without a user.
 
 Run `python manage.py createsuperuser` to create a super user.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ add GMAP_API_KEY(the actual value is in team's doc) to file .env like the follow
 ```
 GMAP_API_KEY='ddN3i59_QccZTqB4cWGy'
 ```
+Adapt your local DJANGO_STATIC_ROOT value accordingly in your .env file. The following is an example.
+
+```
+DJANGO_STATIC_ROOT='/Users/mkranz/Documents/Spectrum/PrevalenceMap/spectrum-autism-prevalence-map/spectrum/autism_prevalence_map/static'
+```
 
 Add your postgres db info into .env. The following is an example.
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/js/list.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/js/list.js
@@ -148,8 +148,6 @@ $(document).ready(function (){
                     "<b>Sex ratio (M:F):</b> " + d.properties.sexratiomf + "<br />" +
                     "<b>Year(s) studied:</b> " + d.properties.yearsstudied + "<br />" +
                     "<b>Category:</b> " + d.properties.categoryadpddorasd + "<br />" +
-                    "<b>Income Level:</b> " + d.properties.meanincomeofparticipants + "<br />" +
-                    "<b>Education Level:</b> " + d.properties.educationlevelofparticipants + "<br />" +
                     links_string;
                 });
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/js/map.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/js/map.js
@@ -809,8 +809,6 @@ $(document).ready(function (){
         $("#card-confidenceinterval").text(confidenceinterval);
         $("#card-yearsstudied").text(d.properties.yearsstudied);
         $("#card-categoryadpddorasd").text(d.properties.categoryadpddorasd);
-        $("#card-income").text(d.properties.meanincomeofparticipants);
-        $("#card-education").text(d.properties.educationlevelofparticipants);
 
         // add links to card
         let links = [];

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
@@ -37,24 +37,7 @@
                     <option value="high">&gt;100,000</option>
                 </select>
             </div>
-            <div class="form-group">
-                <label class="" for="meanincomeofparticipants">Income</label>
-                <select class="custom-select" id="meanincomeofparticipants">
-                    <option value="all">All</option>
-                    <option value="Low">Low</option>
-                    <option value="Medium">Medium</option>
-                    <option value="High">High</option>
-                </select>
-            </div>
-            <div class="form-group">
-                <label class="" for="educationlevelofparticipants">Education</label>
-                <select class="custom-select" id="educationlevelofparticipants">
-                    <option value="all">All</option>
-                    <option value="Low">Low</option>
-                    <option value="Medium">Medium</option>
-                    <option value="High">High</option>
-                </select>
-            </div>
+            
             {% if template == "list" %}
             <div class="form-group">
                 <label class="" for="min_year" id="earliest-label"></label>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/map.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/map.html
@@ -103,10 +103,6 @@
             <p class="card-text" id="card-yearsstudied"></p>
             <h6 class="card-subtitle font-weight-bold">Category</h6>
             <p class="card-text" id="card-categoryadpddorasd"></p>
-            <h6 class="card-subtitle font-weight-bold">Income</h6>
-            <p class="card-text" id="card-income"></p>
-            <h6 class="card-subtitle font-weight-bold">Education</h6>
-            <p class="card-text" id="card-education"></p>
             <p class="card-text" id="card-links"></p>
         </div>
 


### PR DESCRIPTION
Jira ticket: [SPECWWW-866](https://simonsfoundation.atlassian.net/browse/SPECWWW-866)

To test:

- [x] Check out this branch.
- [x] Reference the README.md file in project root directory to make sure your local environment is set up to access 127.0.0.1:8000 successfully.
- [x] Run command `python manage.py runserver` under directory _spectrum_ where file manage.py is located.
- [x] Compared with the production site on [here](https://prevalence.spectrumnews.org/?min_yearpublished=&max_yearpublished=&yearsstudied_number_min=&yearsstudied_number_max=&min_samplesize=&max_samplesize=&min_prevalenceper10000=&max_prevalenceper10000=&studytype=&keyword=&timeline_type=published&meanincome=&education=), and access frontend [page](http://127.0.0.1:8000/?min_yearpublished=&max_yearpublished=&yearsstudied_number_min=&yearsstudied_number_max=&min_samplesize=&max_samplesize=&min_prevalenceper10000=&max_prevalenceper10000=&studytype=&keyword=&timeline_type=published&meanincome=&education=), confirming "income" and "education" are not on the filter options.
- [x] On the above page, click on any blue dot on the map to display a card, and confirm both "income" and "education" are not there anymore.
- [x] Access the [list page](http://127.0.0.1:8000/list/?min_yearpublished=&max_yearpublished=&yearsstudied_number_min=&yearsstudied_number_max=&min_samplesize=&max_samplesize=&min_prevalenceper10000=&max_prevalenceper10000=&studytype=&keyword=&timeline_type=published&meanincome=&education=), and confirm "income" and "education" are not on the filter options.   