### PR TITLE
TTWWW-354: change the meta info from spectrum to the transmitter

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -7,7 +7,7 @@
 {% block css_block %}
 <!-- Custom map CSS
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<link rel="stylesheet" id="spectrum-style-css"  href="{{css_base}}/wp-content/themes/sfari-spectrum/css/spectrum.min.css?ver=2.0.2" type="text/css" media="all" />
+<link rel="stylesheet" id="spectrum-style-css"  href="https://www.spectrumnews.org/wp-content/themes/sfari-spectrum/css/spectrum.min.css?ver=2.0.2" type="text/css" media="all" />
 <link rel="stylesheet" type="text/css" href="{% static 'autism_prevalence_map/css/about.css' %}">
 {% endblock %}
 

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
@@ -9,15 +9,13 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@spectrum">
-    <meta name="twitter:creator" content="@spectrum">
-    <meta name="twitter:title" content="Global Autism Prevalence Map | Spectrum">
+    <meta name="twitter:title" content="Global Autism Prevalence Map | The Transmitter">
     <meta name="twitter:description" content="The map features a collection of studies on autism prevalence around the world. It highlights places where information is available — and places where information is missing.">
-    <meta name="twitter:image" content="https://prevalence.spectrumnews.org/static/autism_prevalence_map/img/PrevalenceMapSG.png">
-    <meta property="og:title" content="Global Autism Prevalence Map | Spectrum" />
+    <meta name="twitter:image" content="https://autismprevalence.thetransmitter.org/static/autism_prevalence_map/img/PrevalenceMapSG.png">
+    <meta property="og:title" content="Global Autism Prevalence Map | The Transmitter" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://prevalence.spectrumnews.org/" />
-    <meta property="og:image" content="https://prevalence.spectrumnews.org/static/autism_prevalence_map/img/PrevalenceMapSG.png" />
+    <meta property="og:url" content="https://autismprevalence.thetransmitter.org/" />
+    <meta property="og:image" content="https://autismprevalence.thetransmitter.org/static/autism_prevalence_map/img/PrevalenceMapSG.png" />
     <meta property="og:description" content="The map features a collection of studies on autism prevalence around the world. It highlights places where information is available — and places where information is missing." />
 
     <!-- Mobile Specific Metas

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -83,16 +83,7 @@ def about(request):
 	"""
 	  About page
 	"""
-	if os.environ["DJANGO_ALLOWED_HOSTS"] == 'prevalence-staging.spectrumnews.org' :
-		css_base = 'https://staging.spectrumnews.org'
-	elif os.environ["DJANGO_ALLOWED_HOSTS"] == '127.0.0.1' :
-		css_base = 'http://dev.spectrum.test:8010'
-	else :
-		css_base = 'https://www.spectrumnews.org'
-	context_dict = {
-		'css_base' : css_base,
-	}
-	return render(request, 'autism_prevalence_map/about.html', context_dict)
+	return render(request, 'autism_prevalence_map/about.html')
 
 
 def studiesApi(request):


### PR DESCRIPTION
https://simonsfoundation.atlassian.net/browse/TTWWW-354

- [x] check out this branch
- [x] go to http://127.0.0.1:8000/
- [x] confirm that the meta tags are now pointing to the new prevalence map URL, and the meta title mentions the transmitter instead of spectrum
- [x] go to http://127.0.0.1:8000/about
- [x] confirm that the min.css is pulled from spectrunews.org and not from other places