### PR TITLE
TTWWW-506: Changing link for "Spectrum" to the Spectrum pathway page

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -36,7 +36,7 @@
             <div id="wp-content">
                 <div id="1" class="chapter-start"></div>
                 <h2 id="about">About the map:</h2>
-                <p>This map was created by the team at <a href="https://www.thetransmitter.org/"><i>Spectrum</i></a>, the leading source of news and expert opinion on autism research. (<a href="https://www.thetransmitter.org/newsletters-alerts/">Subscribe to our newsletters</a>.)</p>
+                <p>This map was created by the team at <a href="https://www.thetransmitter.org/spectrum/"><i>Spectrum</i></a>, the leading source of news and expert opinion on autism research. (<a href="https://www.thetransmitter.org/newsletters-alerts/">Subscribe to our newsletters</a>.)</p>
                 <p>The map features a collection of studies on autism prevalence around the world. It highlights places where information is available — and places where information is missing.</p>
                 <p>Each dot on the map represents a study. To identify these studies, we relied on our expert advisers. The darker dots represent studies that are recommended by the advisors for one or more reasons — although these studies may still be flawed in other aspects.</p>
                 <p>We plan to update the map with new studies as they become available.</p>


### PR DESCRIPTION
It was pointing at the TT site in general, rather than the Spectrum page in particular

To test
- [ ] load the [local site](http://127.0.0.1:8000/about/)
- [ ] confirm the word "Spectrum" in the first sentence links to the [Spectrum page](https://www.thetransmitter.org/spectrum/) on TT

	modified:   spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html