### PR TITLE
TTWWW-477: Small update to allow map to work with active links

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -21,7 +21,7 @@ export function ttInitJoint() {
         app.runUpdate = function() {
             // run update
             app.updateURL();
-            if ($('#map-link').hasClass('active')) {
+            if ($('#map-link').hasClass('text-red')) {
                 app.map.pullDataAndUpdate();
             } else {
                 app.list.addRows();


### PR DESCRIPTION
The code previously was looking for the class 'active' on the main navigation links. This changed where now the class text--red is in place when a link is active. This difference is breaking the map when filters are used.