### PR TITLE
Removed underline from calculate and download buttons

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
@@ -74,9 +74,9 @@
     </div>
 
     <div class="absolute right-0 flex items-start flex-wrap justify-end w-buttons">
-        <a role='button' id='calculate-mean' class='inline-block w-button pt-2.4 pb-2.4 mr-4 box-border bg-light-gray border-0.5 border-navy rounded-sm text-sm font-bold text-med-navy uppercase text-center' href='#'>Calculate Mean</a>
+        <a role='button' id='calculate-mean' class='inline-block w-button pt-2.4 pb-2.4 mr-4 box-border bg-light-gray border-0.5 border-navy rounded-sm text-sm font-bold text-med-navy uppercase text-center no-underline' href='#'>Calculate Mean</a>
 
-        <a role='button' id='download-link' class='inline-block w-button pt-2.5 pb-2.5 bg-med-navy rounded-sm text-sm font-bold text-white uppercase text-center' href='#'>Download Data</a>
+        <a role='button' id='download-link' class='inline-block w-button pt-2.5 pb-2.5 bg-med-navy rounded-sm text-sm font-bold text-white uppercase text-center no-underline' href='#'>Download Data</a>
 
         <button type='button' id='copy-link' class='mt-4 text-2xs text-navy hover:text-red font-bold uppercase text-left'>
             <img src="{% static 'autism_prevalence_map/img/icon-link.svg' %}" alt='link icon' class='inline-block pr-1.5 translate-y-neg1'>Cite The Map (<span id='citation-count'>0</span>)


### PR DESCRIPTION
In QA, the calculate and download buttons have an underline that should not be there. This removes that underline