### PR TITLE
TTWWW-471: updated how pinned items work and added a clear pinned items function

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -19,9 +19,12 @@ export function ttInitJoint() {
 
         // function for updating content based on filters
         app.runUpdate = function() {
+            // clear anything pinned on the map or timeline
+            app.map.clearPinned();
+            
             // run update
             app.updateURL();
-            if ($('#map-link').hasClass('text-red')) {
+            if ($('#map-link').hasClass('text-red') || $('#map-link').hasClass('active')) {
                 app.map.pullDataAndUpdate();
             } else {
                 app.list.addRows();
@@ -324,6 +327,9 @@ export function ttInitJoint() {
             if ($('#map-link').hasClass('active')) {
                 app.map.clearTimelineBrush();
             }
+
+            // clear anything pinned on the map or timeline
+            app.map.clearPinned();
 
             // run update
             app.runUpdate();

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -777,10 +777,6 @@ export function ttInitMap() {
             // mark as pinned
             pinnedDot = pk;
 
-            // show tooltips on map and timeline
-            $('#map_dot_' + pk).tooltip('show');
-            $('#timeline_dot_' + pk).tooltip('show');
-
             // pinned state is blue with white border
             d3.select('#map_dot_' + pk)
                 .style('fill', '#0B6BC3')
@@ -797,10 +793,6 @@ export function ttInitMap() {
         function unpinDot(pk) {
             pinnedDot = null;
 
-            // hide tooltips on map and timeline
-            $('#map_dot_' + pk).tooltip('hide');
-            $('#timeline_dot_' + pk).tooltip('hide');
-
             // revert to default color
             d3.select('#map_dot_' + pk)
                 .style('fill', pointColor)
@@ -812,6 +804,17 @@ export function ttInitMap() {
             // show the welcome card
             showWelcomeCard();
         }
+
+        // function to clear pinned dot when the clear filters button is clicked, or filters are changed.
+        function clearPinned() {
+            if (pinnedDot) {
+                unpinDot(pinnedDot);
+                pinnedDot = null;
+            }
+        }
+
+        // make this clearPinned function available to call from joint.ts
+        app.map.clearPinned = clearPinned;
 
         // populate the info card when a map or timline dot is clicked
         function populateCard(d) {
@@ -868,6 +871,10 @@ export function ttInitMap() {
 
         function togglePin(d) {
             const pk = d.properties.pk;
+
+            $('#map_dot_' + pk).tooltip('hide');
+            $('#timeline_dot_' + pk).tooltip('hide');
+
             // if we clicked the same dot again, unpin
             if (pinnedDot === pk) {
                 unpinDot(pk);


### PR DESCRIPTION
Comments from Sam and Joel on TTWWW-471 indicated that we want to change back to tooltips only showing on hover. This addresses that update. Now tooltips show in hover. On click, the map pin turns the blue color, but the tooltip hides when hovered off.

Additional comments on TTWWW-469 around "phantom studies" are addressed here too. This happened when a dot was pinned, then filters were adjusted to where that pin would no longer show. In that case, the tooltip stayed visible. I added a function to clear all pinned items, then trigger this function when filters are adjusted, or the clear button is clicked.