### PR TITLE
TTWWW-475: Updated pinned dot color for timeline map pins

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -824,7 +824,7 @@ export function ttInitMap() {
                 .style('fill', '#0B6BC3')
                 .style('stroke', '#FFF');
             d3.select('#timeline_dot_' + pk)
-                .style('fill', '#0B6BC3')
+                .style('fill', '#FEF9EE')
                 .style('stroke', '#FFF');
 
             // populate and show info card


### PR DESCRIPTION
Based on design's comment: https://simonsfoundation.atlassian.net/browse/TTWWW-475?focusedCommentId=110223

I have made the selected dot color on the timeline: #FEF9EE