### PR TITLE
TTWWW-568: Sticky nav for prevalence map

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
@@ -54,7 +54,7 @@
 </head>
 
 <body class='font-sans bg-tan' data-page='{% block page_name %}{% endblock %}'>
-    <header class='top-0 w-full px-10 py-4.7 border-b border-black bg-white'>
+    <header class='sticky top-0 w-full px-10 py-4.7 border-b border-black bg-white z-10'>
         <div class='flex justify-between items-center w-full mx-auto max-w-container'>
             <div class='flex items-center space-x-8'>
                 <a class='max-w-logo flex items-center' href='https://www.thetransmitter.org/'>


### PR DESCRIPTION
Task: https://simonsfoundation.atlassian.net/browse/TTWWW-568

- [x]  pull branch c3pojs/TTWWW-568
- [x]  run npm build dev on the autism_prevalence_map folder to compile CSS changes
- [x] Make sure that the header is sticky to the top of the page

