### PR TITLE
TTWWW-571: Show multiple links on study card

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
@@ -171,7 +171,7 @@ module.exports = {
                 'map-xl': '72.125rem',  // 1154px
             },
             maxHeight: {
-                'info': 'calc(100% - 52px)', // height of the info card minus the sticky button wrapper at the bottom with 1 link
+                'info1': 'calc(100% - 52px)', // height of the info card minus the sticky button wrapper at the bottom with 1 link
                 'info2': 'calc(100% - 79px)', // height of the info card minus the sticky button wrapper at the bottom with 2 links
                 'info3': 'calc(100% - 106px)', // height of the info card minus the sticky button wrapper at the bottom with 3 links
                 'info4': 'calc(100% - 133px)', // height of the info card minus the sticky button wrapper at the bottom with 4 links
@@ -321,6 +321,7 @@ module.exports = {
         'ui-slider-handle',
         'ui-slider-range',
         'ui-state-focus',
+        'max-h-info1',
         'max-h-info2',
         'max-h-info3',
         'max-h-info4',

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
@@ -171,7 +171,10 @@ module.exports = {
                 'map-xl': '72.125rem',  // 1154px
             },
             maxHeight: {
-                'info': 'calc(100% - 40px)', // height of the info card minus the sticky button at the bottom
+                'info': 'calc(100% - 52px)', // height of the info card minus the sticky button wrapper at the bottom with 1 link
+                'info2': 'calc(100% - 79px)', // height of the info card minus the sticky button wrapper at the bottom with 2 links
+                'info3': 'calc(100% - 106px)', // height of the info card minus the sticky button wrapper at the bottom with 3 links
+                'info4': 'calc(100% - 133px)', // height of the info card minus the sticky button wrapper at the bottom with 4 links
             },
             maxWidth: {
                 'tooltip': '11.625rem', // 186px
@@ -318,5 +321,8 @@ module.exports = {
         'ui-slider-handle',
         'ui-slider-range',
         'ui-state-focus',
+        'max-h-info2',
+        'max-h-info3',
+        'max-h-info4',
     ],
 }

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -950,16 +950,14 @@ export function ttInitMap() {
                 $('#info-card-container').append(containerHTML);
 
                 // adjust info-card height based on number of links
-                let heightClass = links.length > 1 ? 'max-h-info' + (links.length) : '';
+                let heightClass =  'max-h-info' + (links.length);
 
                 // remove existing height classes before adding a new one
                 infoCard.removeClass(function(index, className) {
                     return (className.match(/max-h-info\d+/g) || []).join(' ');
                 });
 
-                if (heightClass) {
-                    $('#info-card').addClass(heightClass);
-                }
+                $('#info-card').addClass(heightClass);
             }
         }
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -870,6 +870,7 @@ export function ttInitMap() {
 
         // populate the info card when a map or timline dot is clicked
         function populateInfoCard(d) {
+            const infoCard = $('#info-card');
             const authors = d.properties.authors;
             const card_title = authors + ' ' + d.properties.yearpublished;
             const area = d.properties.area.replace(/ *([|]) */g, '$1').split('|').join(', ');
@@ -898,35 +899,67 @@ export function ttInitMap() {
                 '<p class="' + resultCSS1 + '"><strong class="' + resultCSS2 + '">Years Studied:</strong> ' + d.properties.yearsstudied + '</p>' +
                 '<p class="' + resultCSS1 + '"><strong class="' + resultCSS2 + '">Category:</strong> ' + d.properties.categoryadpddorasd + '</p>';
 
+            // check if a string is a valid URL
+            function isValidURL(url) {
+                try {
+                    new URL(url);
+                    return true;
+                } catch (_) {
+                    return false;
+                }
+            }
+
             // remove any previously injected publication link
             $('#publication-button-wrap').remove();
 
             // update the info card content
-            $('#info-card').attr('data-content','').html(cardHTML);
+            infoCard.attr('data-content','').html(cardHTML);
 
-            // Build an array of publication link HTML strings
+            // build an array of publication link HTML strings
             let links = [];
-            let linkClasses = 'block pl-4 text-4 text-blue font-semibold tracking-2 leading-6.25 no-underline rounded-sm2-b';
+            let itemClasses = 'block pl-4 text-4 text-blue font-semibold tracking-2 leading-6.25 no-underline rounded-sm2-b';
 
-            if (d.properties.link1title && d.properties.link1url) {
-                links.push('<a href="' + d.properties.link1url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link1title + '</a>');
-            }
-            if (d.properties.link2title && d.properties.link2url) {
-                links.push('<a href="' + d.properties.link2url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link2title + '</a>');
-            }
-            if (d.properties.link3title && d.properties.link3url) {
-                links.push('<a href="' + d.properties.link3url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link3title + '</a>');
-            }
-            if (d.properties.link4title && d.properties.link4url) {
-                links.push('<a href="' + d.properties.link4url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link4title + '</a>');
+            const publications = [
+                { title: d.properties.link1title, url: d.properties.link1url },
+                { title: d.properties.link2title, url: d.properties.link2url },
+                { title: d.properties.link3title, url: d.properties.link3url },
+                { title: d.properties.link4title, url: d.properties.link4url }
+            ];
+
+            for (let i = 0; i < publications.length; i++) {
+                const publication = publications[i];
+                if (publication.title && publication.url) {
+                    let item;
+                    if (isValidURL(publication.url)) {
+                        // use an anchor tag if we have a valid URL
+                        item = '<a href="' + publication.url + '" target="_blank" class="' + itemClasses + (i > 0 ? ' mt-0.5' : '') + '">' + publication.title + '</a>';
+                    } else {
+                        // use a span if we don't have a valid URL
+                        item = '<span class="' + itemClasses + (i > 0 ? ' mt-0.5' : '') + '">' + publication.title + '</span>';
+                    }
+                    links.push(item);
+                }
             }
 
             // add the publication links into an absolutely positioned div at the bottom of the parent while the main #info-card has overflow: scroll
             if (links.length > 0) {
                 let linksHTML = links.join('');
                 linksHTML = linksHTML.replace('>Spectrum', '><em>Spectrum</em>');
+
                 const containerHTML = '<div id="publication-button-wrap" class="absolute bottom-0 left-0 w-full py-3.25 bg-white border-t-light-gray2 border-t-0.5 rounded-sm2-b">' + linksHTML + '</div>';
                 $('#info-card-container').append(containerHTML);
+
+                // adjust info-card height based on number of links
+                let heightClass = links.length > 1 ? 'max-h-info' + (links.length) : '';
+
+                // remove existing height classes before adding a new one
+                infoCard.removeClass(function(index, className) {
+                    return (className.match(/max-h-info\d+/g) || []).join(' ');
+                });
+
+                if (heightClass) {
+                    $('#info-card').addClass(heightClass);
+                }
             }
         }
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -906,26 +906,26 @@ export function ttInitMap() {
 
             // Build an array of publication link HTML strings
             let links = [];
-            let linkClasses = 'block pl-4 text-4 text-blue tracking-2 leading-6.25 no-underline rounded-sm2-b';
+            let linkClasses = 'block pl-4 text-4 text-blue font-semibold tracking-2 leading-6.25 no-underline rounded-sm2-b';
 
             if (d.properties.link1title && d.properties.link1url) {
                 links.push('<a href="' + d.properties.link1url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link1title + '</a>');
             }
             if (d.properties.link2title && d.properties.link2url) {
-                links.push('<a href="' + d.properties.link2url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link2title + '</a>');
+                links.push('<a href="' + d.properties.link2url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link2title + '</a>');
             }
             if (d.properties.link3title && d.properties.link3url) {
-                links.push('<a href="' + d.properties.link3url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link3title + '</a>');
+                links.push('<a href="' + d.properties.link3url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link3title + '</a>');
             }
             if (d.properties.link4title && d.properties.link4url) {
-                links.push('<a href="' + d.properties.link4url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link4title + '</a>');
+                links.push('<a href="' + d.properties.link4url + '" target="_blank" class="' + linkClasses + ' mt-0.5">' + d.properties.link4title + '</a>');
             }
 
             // add the publication links into an absolutely positioned div at the bottom of the parent while the main #info-card has overflow: scroll
             if (links.length > 0) {
                 let linksHTML = links.join('');
                 linksHTML = linksHTML.replace('>Spectrum', '><em>Spectrum</em>');
-                const containerHTML = '<div id="publication-button-wrap" class="absolute bottom-0 left-0 w-full py-1.75 bg-white border-t-light-gray2 border-t-0.5 rounded-sm2-b">' + linksHTML + '</div>';
+                const containerHTML = '<div id="publication-button-wrap" class="absolute bottom-0 left-0 w-full py-3.25 bg-white border-t-light-gray2 border-t-0.5 rounded-sm2-b">' + linksHTML + '</div>';
                 $('#info-card-container').append(containerHTML);
             }
         }

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -899,41 +899,40 @@ export function ttInitMap() {
                 '<p class="' + resultCSS1 + '"><strong class="' + resultCSS2 + '">Category:</strong> ' + d.properties.categoryadpddorasd + '</p>';
 
             // remove any previously injected publication link
-            $('#publication-button').remove();
+            $('#publication-button-wrap').remove();
 
             // update the info card content
             $('#info-card').attr('data-content','').html(cardHTML);
 
-            /*
-            Leaving this for post launch to address
+            // Build an array of publication link HTML strings
             let links = [];
+            let linkClasses = 'block pl-4 text-4 text-blue tracking-2 leading-6.25 no-underline rounded-sm2-b';
+
             if (d.properties.link1title && d.properties.link1url) {
-                links.push('<a href="'+ d.properties.link1url +'">'+ d.properties.link1title +'</a>');
+                links.push('<a href="' + d.properties.link1url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link1title + '</a>');
             }
             if (d.properties.link2title && d.properties.link2url) {
-                links.push('<a href="'+ d.properties.link2url +'">'+ d.properties.link2title +'</a>');
+                links.push('<a href="' + d.properties.link2url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link2title + '</a>');
             }
             if (d.properties.link3title && d.properties.link3url) {
-                links.push('<a href="'+ d.properties.link3url +'">'+ d.properties.link3title +'</a>');
+                links.push('<a href="' + d.properties.link3url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link3title + '</a>');
             }
             if (d.properties.link4title && d.properties.link4url) {
-                links.push('<a href="'+ d.properties.link4url +'">'+ d.properties.link4title +'</a>');
+                links.push('<a href="' + d.properties.link4url + '" target="_blank" class="' + linkClasses + '">' + d.properties.link4title + '</a>');
             }
 
-            let links_string = links.join('<br />');
-            links_string = links_string.replace('>Spectrum', '><em>Spectrum</em>');
-            */
-
-            // add the publication link that is absolutely positioned at the bottom of the parent while the main #info-card has overflow: scroll
-            if (d.properties.link1title && d.properties.link1url) {
-                const linkHTML = '<a href="' + d.properties.link1url + '" id="publication-button" class="absolute bottom-0 left-0 w-full pl-4 py-1.75 bg-white border-t-light-gray2 border-t-0.5 rounded-sm2-b text-4 text-blue tracking-2 leading-6.25 no-underline" target="_blank">' + d.properties.link1title + '</a>';
-                $('#info-card-container').append(linkHTML);
+            // add the publication links into an absolutely positioned div at the bottom of the parent while the main #info-card has overflow: scroll
+            if (links.length > 0) {
+                let linksHTML = links.join('');
+                linksHTML = linksHTML.replace('>Spectrum', '><em>Spectrum</em>');
+                const containerHTML = '<div id="publication-button-wrap" class="absolute bottom-0 left-0 w-full py-1.75 bg-white border-t-light-gray2 border-t-0.5 rounded-sm2-b">' + linksHTML + '</div>';
+                $('#info-card-container').append(containerHTML);
             }
         }
 
         // reset to welcome card content
         function showWelcomeCard() {
-            $('#publication-button').remove();
+            $('#publication-button-wrap').remove();
             $('#info-card').html(welcomeCardContent).attr('data-content', 'welcome');
         }
 

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/map.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/map.html
@@ -14,7 +14,7 @@
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <div class='flex mb-6 xl:mb-10'>
         <div id='info-card-container' class='relative h-map lg:h-map-lg xl:h-card-xl w-info lg:mr-10.5 xl:mr-12 pt-4 bg-white border-0.5 border-light-gray3 rounded-md shadow-info'>
-            <div id='info-card' data-content='welcome' class='relative max-h-info overflow-y-scroll px-4 pb-0.75'>
+            <div id='info-card' data-content='welcome' class='relative overflow-y-scroll px-4 pb-0.75'>
                 <h1 class='mt-24 lg:mt-25.5 xl:mt-46.5 mb-3.25 max-w-welcome font-serif text-2md font-bold leading-7.2 text-med-navy'>Welcome to the Global Autism Prevalence Map.</h1>
                 <p class='mb-9 max-w-welcome font-serif text-sm3 leading-4.5 text-dark-gray2'>Click on any dot on the map to view detailed information about a study. Data from that study will be displayed in this panel.</p>
                 <a href='/about/' class='inline-block w-learn py-2.5 bg-med-navy rounded-sm text-sm font-bold text-light-navy-2 uppercase text-center no-underline'>Learn More</a>


### PR DESCRIPTION
Referencing this Jira ticket: https://simonsfoundation.atlassian.net/browse/TTWWW-571

I updated to account for all 4 links that were originally in the code. 

- [x] pull this branch
- [x] compile CSS and JS changes
- [x] from the map page, click on a map pin with a single publication link and confirm that the single link looks correct. We are now using a little more top and bottom padding and the font-weight increased from the previous design.
- [x] from the map page, click on a map pin that has more than one publication link, and confirm that both links look correct based on the new design in Figma (https://www.figma.com/design/wcJ1rzoLOkRaVuKp2Zae6F/Prevalence-Map?node-id=2130-6654&t=DJRnnIiquUAnxMc1-1). Locally, the study "Sun X. et al. 2019 in Shenzhen, China" has two links