### PR TITLE
TTWWW-573: add box to show calculated mean on page

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
@@ -118,6 +118,7 @@ module.exports = {
             letterSpacing: {
                 '1': '0.01em', // 1%
                 '2': '0.02em', // 2%
+                '4': '0.04em', // 4%
                 'normal-md': '0.016em', // 0.26px
                 'normal-lg': '0.02em', // 0.32px
                 'widest-sm': '0.14em', // 1.92px
@@ -179,6 +180,7 @@ module.exports = {
                 'filterwide': '15.375rem', // 246px
                 'info': '18rem', // 288px
                 'mean-popup': '23.6875rem', //379px
+                'mean-popup-note': '26.5rem', //424px
                 'buttons': '25rem', // 400px
                 'listcard': '25.5rem', // 408px
                 'map': '51.625rem', // 826px
@@ -271,6 +273,7 @@ module.exports = {
                 'light-navy-3': '#6c8291',
                 'light-navy-2': '#DFE8EC',
                 'tan': '#FEF9EE',
+                'med-tan': '#F4EEDF',
                 'dark-tan': '#CAC6BC',
                 'dark-gray': '#2D2D2D',
                 'dark-gray2': '#585248',

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -95,7 +95,7 @@ export function ttInitJoint() {
             } else {
                 app.list.addRows();
             }
-
+            // update the mean
             app.fetchAndUpdateMean();
         }
 
@@ -187,6 +187,9 @@ export function ttInitJoint() {
             } else {
                 $('#max_year').val($('#max_year option:last').val());
             }
+
+            // initial fetch of mean value
+            app.meanValue = data.mean;
         });
 
         function onlyUnique(value, index, self) {
@@ -573,21 +576,17 @@ export function ttInitJoint() {
             hoverActive: false
         };
 
-        // function to udpate the mean for both map and list
+        // function to update the mean for both map and list
         app.fetchAndUpdateMean = function() {
-            d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
-                if (data && data.mean) {
-                    var meanValue = data.mean;
-            
-                    // update button attribute
-                    $('[data-mean]').attr('data-mean', meanValue);
-                    
-                    // update static box if it is visible
-                    if (!$('#mean-static').hasClass('hidden')) {
-                        $staticText.text(staticTextTemplate.replace('{value}', meanValue || ''));
-                    }
+            if (app.meanValue) {
+                // update button attribute
+                $('[data-mean]').attr('data-mean', app.meanValue);
+                
+                // update static box if it is visible
+                if (!$('#mean-static').hasClass('hidden')) {
+                    $staticText.text(staticTextTemplate.replace('{value}', app.meanValue || ''));
                 }
-            });
+            }
         };
 
         $meanButton.on('click', function () {
@@ -649,9 +648,6 @@ export function ttInitJoint() {
                 $meanPopup.addClass('hidden').attr('aria-hidden', 'true');
             }
         });
-
-        // initial fetch of mean value
-        app.fetchAndUpdateMean();
 
         // for the search field, handle the 'X' functionality and clearing keyword from URL
         const searchInput = document.querySelector('[data-id="keyword-filter-input"]') as HTMLInputElement;

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -95,6 +95,8 @@ export function ttInitJoint() {
             } else {
                 app.list.addRows();
             }
+
+            app.fetchAndUpdateMean();
         }
 
         d3.json('/studies-api/').then(function(data) {
@@ -555,15 +557,6 @@ export function ttInitJoint() {
         // calculate the citation count
         getCitationCount(citationURL);
 
-        // function to udpate the mean for both map and list
-        app.fetchAndUpdateMean = function() {
-            d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
-                if (data && data.mean) {
-                    $('[data-mean]').attr('data-mean', data.mean);
-                }
-            });
-        };
-
         // show the calculate mean popup and handle the copy to clipboard when the calculate mean button is clicked, show the note when hovered
         var $meanButton = $('[data-mean]');
         var $meanPopup = $('#mean-popup');
@@ -578,6 +571,23 @@ export function ttInitJoint() {
         var popupState = {
             clickTriggered: false,
             hoverActive: false
+        };
+
+        // function to udpate the mean for both map and list
+        app.fetchAndUpdateMean = function() {
+            d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
+                if (data && data.mean) {
+                    var meanValue = data.mean;
+            
+                    // update button attribute
+                    $('[data-mean]').attr('data-mean', meanValue);
+                    
+                    // update static box if it is visible
+                    if (!$('#mean-static').hasClass('hidden')) {
+                        $staticText.text(staticTextTemplate.replace('{value}', meanValue || ''));
+                    }
+                }
+            });
         };
 
         $meanButton.on('click', function () {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -264,7 +264,6 @@ export function ttInitList() {
                 });
 
                 app.fetchAndUpdateMean();
-                return data;
             });
         }
         

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -97,6 +97,7 @@ export function ttInitList() {
             $('#studies-table tbody').remove();     
             d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
                 studies = data;
+                app.meanValue = data.mean;
 
                 // update the results count
                 document.getElementById('results-count').textContent = studies.features.length;
@@ -261,6 +262,9 @@ export function ttInitList() {
                         app.list.renderMiniMap(studyData, 'map_placeholder_' + pk);
                     }
                 });
+
+                app.fetchAndUpdateMean();
+                return data;
             });
         }
         

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -159,7 +159,10 @@ export function ttInitMap() {
             app.updateURL();
             d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
                 studies = data;
+                app.meanValue = data.mean;
                 app.map.updateTimeline();
+                app.fetchAndUpdateMean();
+                return data;
             });
         }
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -159,7 +159,6 @@ export function ttInitMap() {
             app.updateURL();
             d3.json('/studies-api/' + app.api_call_param_string).then(function(data) {
                 studies = data;
-                $('[data-mean]').attr('data-mean', data.mean);
                 app.map.updateTimeline();
             });
         }

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -162,7 +162,6 @@ export function ttInitMap() {
                 app.meanValue = data.mean;
                 app.map.updateTimeline();
                 app.fetchAndUpdateMean();
-                return data;
             });
         }
 

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
@@ -84,7 +84,7 @@
             <span data-id='mean-static-text'></span>
         </div>
 
-        <div id='mean-popup' class='absolute top-12.5 right-52 z-2 hidden bg-light-gray shadow-mean-popup rounded-md px-4 py-2.4 border-0.5 border-light-gray2 w-mean-popup font-serif text-2xs2 text-dark-gray2' role='dialog' aria-hidden='true'>
+        <div id='mean-popup' class='absolute top-12.5 right-52 z-2 hidden bg-light-gray shadow-mean-popup rounded-md px-4 py-2.4 border-0.125 border-light-gray2 w-mean-popup font-serif text-2xs2 text-dark-gray2' role='dialog' aria-hidden='true'>
             <span data-id='mean-data-line' class='flex items-center gap-2'>{% svg 'icon-copy' %} <span data-id='mean-popup-text'></span></span>
             <span data-id='mean-note-line' class='block py-0.75 text-2xs tracking-4 hidden'>Note: This button calculates the mean prevalence of all studies currently included within the filter range but does not account for a weighted average of the effect estimates from the different studies.</span>
         </div>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/action_buttons.html
@@ -80,9 +80,13 @@
             <span id='citation-url' class='block pt-0.75 text-xs text-med-navy'>https://doi.org/10.53053/NDWR8664</span>
         </button>
 
-        <div id='mean-popup' class='absolute top-11.5 right-52 hidden bg-light-gray shadow-mean-popup rounded-md p-4 border-0.125 border-light-gray2 w-mean-popup font-serif text-2xs2 text-dark-gray2' role='dialog' aria-hidden='true'>
-            <span class='flex items-center gap-2'>{% svg 'icon-copy' %} <span data-id='mean-popup-text' class='uppercase'></span></span>
-            <span class='block mt-2 text-2xs tracking-normal-md'>Note: This button calculates the mean prevalence of all studies currently included within the filter range but does not account for a weighted average of the effect estimates from the different studies.</span>
+        <div id='mean-static' class='absolute hidden top-12.5 left-0 px-2.25 py-0.5 bg-med-tan rounded-sm text-sm font-bold text-med-navy' role='dialog' aria-hidden='true'>
+            <span data-id='mean-static-text'></span>
+        </div>
+
+        <div id='mean-popup' class='absolute top-12.5 right-52 z-2 hidden bg-light-gray shadow-mean-popup rounded-md px-4 py-2.4 border-0.5 border-light-gray2 w-mean-popup font-serif text-2xs2 text-dark-gray2' role='dialog' aria-hidden='true'>
+            <span data-id='mean-data-line' class='flex items-center gap-2'>{% svg 'icon-copy' %} <span data-id='mean-popup-text'></span></span>
+            <span data-id='mean-note-line' class='block py-0.75 text-2xs tracking-4 hidden'>Note: This button calculates the mean prevalence of all studies currently included within the filter range but does not account for a weighted average of the effect estimates from the different studies.</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR is for this Jira ticket: https://simonsfoundation.atlassian.net/browse/TTWWW-573

- [x] pull this branch
- [x] compile CSS and JS updates
- [x] hover the Calculate Mean button and confirm that the popup with the note shows
- [x] click the Calculate Mean button and confirm that the correct text with calculate mean shows (the note should no longer show)
- [x] after clicking the Calculate Mean button, confirm that the mean value was copied to your clipboard
- [x] after clicking the Calculate Mean button, confirm that the popup containing the calculated mean hides after 3 seconds (mousing off and mousing back on should show the note, but this will not affect the timeout for the mean being shown)
- [x] after clicking the Calculate Mean button, confirm that the new box is shown with the same value and matches the design in [Figma](https://www.figma.com/design/wcJ1rzoLOkRaVuKp2Zae6F/Prevalence-Map?node-id=2130-4550&t=GeA6x3XQPQDZ3THK-1)
- [x] after clicking the Calculate Mean button, and the new box is shown, update the current filters on the page and confirm that the mean value in the new box also updates