### PR TITLE
TTWWW-573: QA updates

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -2,6 +2,8 @@ import { app } from './app.js';
 
 export function ttInitJoint() {
     $(document).ready(function () {
+        app.meanBoxVisible = sessionStorage.getItem('meanBoxVisible') === 'true';
+
         $(document).on('click', '[data-function="cookie-banner-set-consent"]', function (e) {
             e.preventDefault();
             let cookieValue = $(this).data('cookie-value');
@@ -430,6 +432,11 @@ export function ttInitJoint() {
             // remove the search input close X
              $('[data-id="keyword-filter-x-btn"]').addClass('hidden');
           
+            // hide the mean box
+            app.meanBoxVisible = false;
+            sessionStorage.removeItem('meanBoxVisible');
+            $('#mean-static').addClass('hidden').attr('aria-hidden', 'true');
+
             // run update
             app.runUpdate();
         });
@@ -599,8 +606,12 @@ export function ttInitJoint() {
                 $('[data-mean]').attr('data-mean', app.meanValue);
                 
                 // update static box if it is visible
-                if (!$('#mean-static').hasClass('hidden')) {
-                    $staticText.text(staticTextTemplate.replace('{value}', app.meanValue || ''));
+                if (app.meanBoxVisible) {
+                    var $staticText = $('#mean-static').find('[data-id="mean-static-text"]');
+                    if ($staticText.length) {
+                        $staticText.text('MEAN = ' + app.meanValue);
+                        $('#mean-static').removeClass('hidden').attr('aria-hidden', 'false');
+                    }
                 }
             }
         };
@@ -633,6 +644,10 @@ export function ttInitJoint() {
                 $meanPopup.addClass('hidden').attr('aria-hidden', 'true');
                 popupState.clickTriggered = false;
             }, 3000);
+
+            // set a flag for the mean box and store in session storage
+            app.meanBoxVisible = true;
+            sessionStorage.setItem('meanBoxVisible', 'true');
         });
 
         $meanButton.on('mouseenter', function() {
@@ -697,6 +712,11 @@ export function ttInitJoint() {
         } else {
             $('#earliest-label').text('Earliest year published');
             $('#latest-label').text('Latest year published');
+        }
+
+        // initialize mean box visibility
+        if (app.meanBoxVisible) {
+            app.fetchAndUpdateMean();
         }
     });
 }

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -273,14 +273,22 @@ export function ttInitJoint() {
             let newMin = parseFloat($(this).val());
             if (isNaN(newMin)) newMin = 0;
 
-            // Get current slider max
+            // get current slider max
             let currentMax = $('#prevalence-slider').slider('values', 1);
             if (newMin > currentMax) newMin = currentMax;
 
-            // Update the slider’s min handle
-            $('#prevalence-slider').slider('values', 0, newMin);
-
             min_prevalenceper10000 = newMin.toString();
+            
+            // temporarily disable the slider's change event
+            var originalChangeHandler = $('#prevalence-slider').slider("option", "change");
+            $('#prevalence-slider').slider("option", "change", null);
+            
+            // update the slider value without triggering a change event
+            $('#prevalence-slider').slider('values', 0, newMin);
+            
+            // restore the original event
+            $('#prevalence-slider').slider("option", "change", originalChangeHandler);
+            
             app.runUpdate();
         });
 
@@ -288,14 +296,22 @@ export function ttInitJoint() {
             let newMax = parseFloat($(this).val());
             if (isNaN(newMax)) newMax = 500; // fallback
 
-            // Get current slider min
+            // get current slider min
             let currentMin = $('#prevalence-slider').slider('values', 0);
             if (newMax < currentMin) newMax = currentMin;
 
-            // Update the slider’s max handle
-            $('#prevalence-slider').slider('values', 1, newMax);
-
             max_prevalenceper10000 = newMax.toString();
+            
+            // temporarily disable the slider's change event
+            var originalChangeHandler = $('#prevalence-slider').slider("option", "change");
+            $('#prevalence-slider').slider("option", "change", null);
+            
+            // update the slider value without triggering a change event
+            $('#prevalence-slider').slider('values', 1, newMax);
+            
+            // restore the original event
+            $('#prevalence-slider').slider("option", "change", originalChangeHandler);
+            
             app.runUpdate();
         });
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -176,6 +176,10 @@ export function ttInitMap() {
         app.map.addTimeline = function() {
             timeMin = d3.min(studies.features, function(d) { return new Date(d.properties.yearsstudied_number_min); });
             timeMax = d3.max(studies.features, function(d) { return new Date(d.properties.yearpublished); });
+
+            // extend the timeline to the end of the year of the last available data to allow that year to be selected
+            timeMax = new Date(timeMax.getFullYear() + 1, 11, 31, 23, 59, 59);
+
             // add the x brush
             brush = d3.brushX()
                 .extent([[0, 0], [timelineWidth, timelineHeight-33]])


### PR DESCRIPTION
Addressed two issues here.

First related to the comment on this task [TTWWW-573](https://simonsfoundation.atlassian.net/browse/TTWWW-573?focusedCommentId=111524). I have the static mean box now staying on the page when switching between the map and list pages. Noting that this only clears currently when the clear button is clicked. If you refresh the page, it does not go away. Wanted to get feedback before I did that update as well.

- [ ] click the button to calculate the mean, confirm the static box shows
- [ ] navigate to the other page (navigate to list page if you are on map) and confirm the static box still shows
- [ ] click the clear button and confirm the static box hides

Second related to the comment on this task [TTWWW-475](https://simonsfoundation.atlassian.net/browse/TTWWW-475?focusedCommentId=111556). This only involved adding one line, so I included it in this PR. I extended the timeline to the end of the last data year instead of the beginning. This allows a user to select the last year.

- [ ] drag the timeline selection to the end of the timeline and confirm that this includes the most recent year data. In my case I have 2025 data, so it should include those map points.
 