### PR TITLE
TTWWW-580: Sticky header on List view

### DIFF
--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
@@ -15,7 +15,7 @@
             <div class='pb-3.25 text-2xs uppercase text-med-navy'><span id='results-count'>0</span> results</div>
 
             <table id='studies-table' class='w-full'>
-                <thead class='bg-dark-gray border-b-3 border-tan'>
+                <thead class='bg-dark-gray border-b-3 border-tan sticky top-17.7 z-10'>
                     <tr>
                         <th scope='col' class='w-toggle'></th>
                         <th scope='col'>YEAR</th>


### PR DESCRIPTION
Task: https://simonsfoundation.atlassian.net/browse/TTWWW-580
Figma designs: https://www.figma.com/design/wcJ1rzoLOkRaVuKp2Zae6F/Prevalence-Map?node-id=2118-3703&m=dev

- [x] pull branch c3pojs/TTWWW-580
- [x] run npm build dev on the autism_prevalence_map folder to compile CSS changes
- [x] Make sure that table header is sticky on 'List view' page

<img width="661" alt="image" src="https://github.com/user-attachments/assets/4d280403-e533-4c6b-a6cb-d74e8c41f76f" />



