### PR TITLE
TTWWW-469: Updated min and max filters to not allow min years to be selected that are more than max year

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -1,5 +1,17 @@
 import { app } from './app.js';
 
+// function to update disabled min and max years options that can be called from this file and map.ts
+export function updateYearDropdowns(minYear, maxYear) {
+    if (app.comboBox_max_year) {
+        app.comboBox_max_year.selectAll('option')
+            .property('disabled', function() { return parseInt(this.value) < minYear; });
+    }
+    if (app.comboBox_min_year) {
+        app.comboBox_min_year.selectAll('option')
+            .property('disabled', function() { return parseInt(this.value) > maxYear; });
+    }
+}
+
 export function ttInitJoint() {
     $(document).ready(function () {
         app.meanBoxVisible = sessionStorage.getItem('meanBoxVisible') === 'true';
@@ -68,7 +80,8 @@ export function ttInitJoint() {
             grantGTMConsent();
         }
 
-        let comboBox_min_year, comboBox_max_year;
+        app.comboBox_min_year = null;
+        app.comboBox_max_year = null;
 
         // api call holder
         app.api_call_param_string = '?min_yearpublished='+min_yearpublished+'&max_yearpublished='+max_yearpublished+'&yearsstudied_number_min='+yearsstudied_number_min+'&yearsstudied_number_max='+yearsstudied_number_max+'&min_samplesize='+min_samplesize+'&max_samplesize='+max_samplesize+'&min_prevalenceper10000='+min_prevalenceper10000+'&max_prevalenceper10000='+max_prevalenceper10000+'&studytype='+encodeURIComponent(studytype)+'&keyword='+encodeURIComponent(keyword)+'&timeline_type='+timeline_type+'&meanincome='+income+'&education='+education+'&country='+country+'&continent='+continent;
@@ -160,18 +173,18 @@ export function ttInitJoint() {
             }
 
             // making the combo box options for earliest published and latest published
-            comboBox_min_year = d3.select('#min_year');
-            comboBox_max_year = d3.select('#max_year');
+            app.comboBox_min_year = d3.select('#min_year');
+            app.comboBox_max_year = d3.select('#max_year');
 
             const timeMin = d3.min(data.features, function(d) { return new Date(d.properties.yearsstudied_number_min); }).getUTCFullYear();
             const timeMax = d3.max(data.features, function(d) { return new Date(d.properties.yearpublished); }).getUTCFullYear();
 
             for (let index = timeMin; index <= timeMax; index++) {
-                comboBox_min_year.append('option')
+                app.comboBox_min_year.append('option')
                     .attr('value', index)
                     .text(index);
 
-                comboBox_max_year.append('option')
+                app.comboBox_max_year.append('option')
                     .attr('value', index)
                     .text(index);
             }
@@ -195,10 +208,7 @@ export function ttInitJoint() {
             // disable options based on initial min and max values
             const initialMinYear = parseInt($('#min_year').val());
             const initialMaxYear = parseInt($('#max_year').val());
-            comboBox_max_year.selectAll('option')
-                .property('disabled', function() { return parseInt(this.value) < initialMinYear; });
-            comboBox_min_year.selectAll('option')
-                .property('disabled', function() { return parseInt(this.value) > initialMaxYear; });
+            updateYearDropdowns(initialMinYear, initialMaxYear);
 
             // initial fetch of mean value
             app.meanValue = data.mean;
@@ -227,10 +237,8 @@ export function ttInitJoint() {
             }
             // make sure that max_year is greater than min year
             const minYearSelected = parseInt($(this).val());
-            if (comboBox_max_year) {
-                comboBox_max_year.selectAll('option')
-                    .property('disabled', function() { return parseInt(this.value) < minYearSelected; });
-            }
+            const maxYearSelected = parseInt($('#max_year').val());
+            updateYearDropdowns(minYearSelected, maxYearSelected);
             let selection = d3.select('.selection');
             if (!selection.empty() && selection.attr('display') !== 'none') {
                 app.map.updateTimelineBrushFromFilters();
@@ -246,11 +254,9 @@ export function ttInitJoint() {
                 max_yearpublished = $(this).val();
             }
             // make sure that min year is less than max year
-            const maxYearSelected = parseInt($(this).val());
-            if (comboBox_min_year) {
-                comboBox_min_year.selectAll('option')
-                    .property('disabled', function() { return parseInt(this.value) > maxYearSelected; });
-            }
+            const minYearSelected = parseInt($(this).val());
+            const maxYearSelected = parseInt($('#max_year').val());
+            updateYearDropdowns(minYearSelected, maxYearSelected);
             let selection = d3.select('.selection');
             if (!selection.empty() && selection.attr('display') !== 'none') {
                 app.map.updateTimelineBrushFromFilters();
@@ -441,11 +447,11 @@ export function ttInitJoint() {
             $('#country').val('all');
 
             // re-enable all min and max select options
-            if (comboBox_min_year) {
-                comboBox_min_year.selectAll('option').property('disabled', false);
+            if (app.comboBox_min_year) {
+                app.comboBox_min_year.selectAll('option').property('disabled', false);
             }
-            if (comboBox_max_year) {
-                comboBox_max_year.selectAll('option').property('disabled', false);
+            if (app.comboBox_max_year) {
+                app.comboBox_max_year.selectAll('option').property('disabled', false);
             }
 
             // remove brush from timeline

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -68,6 +68,8 @@ export function ttInitJoint() {
             grantGTMConsent();
         }
 
+        let comboBox_min_year, comboBox_max_year;
+
         // api call holder
         app.api_call_param_string = '?min_yearpublished='+min_yearpublished+'&max_yearpublished='+max_yearpublished+'&yearsstudied_number_min='+yearsstudied_number_min+'&yearsstudied_number_max='+yearsstudied_number_max+'&min_samplesize='+min_samplesize+'&max_samplesize='+max_samplesize+'&min_prevalenceper10000='+min_prevalenceper10000+'&max_prevalenceper10000='+max_prevalenceper10000+'&studytype='+encodeURIComponent(studytype)+'&keyword='+encodeURIComponent(keyword)+'&timeline_type='+timeline_type+'&meanincome='+income+'&education='+education+'&country='+country+'&continent='+continent;
 
@@ -158,8 +160,8 @@ export function ttInitJoint() {
             }
 
             // making the combo box options for earliest published and latest published
-            const comboBox_min_year = d3.select('#min_year');
-            const comboBox_max_year = d3.select('#max_year');
+            comboBox_min_year = d3.select('#min_year');
+            comboBox_max_year = d3.select('#max_year');
 
             const timeMin = d3.min(data.features, function(d) { return new Date(d.properties.yearsstudied_number_min); }).getUTCFullYear();
             const timeMax = d3.max(data.features, function(d) { return new Date(d.properties.yearpublished); }).getUTCFullYear();
@@ -210,13 +212,17 @@ export function ttInitJoint() {
 
         $('#min_year').on('change', function(e) {
             $('#more-information-card').css('display', 'none');
-            // update filters
             if (timeline_type == 'studied') {
                 yearsstudied_number_min = $(this).val();
             } else {
                 min_yearpublished = $(this).val();
             }
-            // update the timeline when selection is actively in use
+            // make sure that max_year is greater than min year
+            const minYearSelected = parseInt($(this).val());
+            if (comboBox_max_year) {
+                comboBox_max_year.selectAll('option')
+                    .property('disabled', function() { return parseInt(this.value) < minYearSelected; });
+            }
             let selection = d3.select('.selection');
             if (!selection.empty() && selection.attr('display') !== 'none') {
                 app.map.updateTimelineBrushFromFilters();
@@ -226,13 +232,17 @@ export function ttInitJoint() {
 
         $('#max_year').on('change', function(e) {
             $('#more-information-card').css('display', 'none');
-            // update filters
             if (timeline_type == 'studied') {
                 yearsstudied_number_max = $(this).val();
             } else {
                 max_yearpublished = $(this).val();
             }
-            // update the timeline when selection is actively in use
+            // make sure that min year is less than max year
+            const maxYearSelected = parseInt($(this).val());
+            if (comboBox_min_year) {
+                comboBox_min_year.selectAll('option')
+                    .property('disabled', function() { return parseInt(this.value) > maxYearSelected; });
+            }
             let selection = d3.select('.selection');
             if (!selection.empty() && selection.attr('display') !== 'none') {
                 app.map.updateTimelineBrushFromFilters();

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -254,8 +254,8 @@ export function ttInitJoint() {
                 max_yearpublished = $(this).val();
             }
             // make sure that min year is less than max year
-            const minYearSelected = parseInt($(this).val());
-            const maxYearSelected = parseInt($('#max_year').val());
+            const maxYearSelected = parseInt($(this).val());
+            const minYearSelected = parseInt($('#min_year').val());
             updateYearDropdowns(minYearSelected, maxYearSelected);
             let selection = d3.select('.selection');
             if (!selection.empty() && selection.attr('display') !== 'none') {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -192,6 +192,14 @@ export function ttInitJoint() {
                 $('#max_year').val($('#max_year option:last').val());
             }
 
+            // disable options based on initial min and max values
+            const initialMinYear = parseInt($('#min_year').val());
+            const initialMaxYear = parseInt($('#max_year').val());
+            comboBox_max_year.selectAll('option')
+                .property('disabled', function() { return parseInt(this.value) < initialMinYear; });
+            comboBox_min_year.selectAll('option')
+                .property('disabled', function() { return parseInt(this.value) > initialMaxYear; });
+
             // initial fetch of mean value
             app.meanValue = data.mean;
         });
@@ -431,6 +439,14 @@ export function ttInitJoint() {
             $('#educationlevelofparticipants').val('all');
             $('#continent').val('all');
             $('#country').val('all');
+
+            // re-enable all min and max select options
+            if (comboBox_min_year) {
+                comboBox_min_year.selectAll('option').property('disabled', false);
+            }
+            if (comboBox_max_year) {
+                comboBox_max_year.selectAll('option').property('disabled', false);
+            }
 
             // remove brush from timeline
             if ($('#map-link').hasClass('text-red') || $('#map-link').hasClass('active')) {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -1,4 +1,5 @@
 import { app } from './app.js';
+import { updateYearDropdowns } from './joint.js';
 
 export function ttInitMap() {
     $(document).ready(function (){
@@ -250,9 +251,13 @@ export function ttInitMap() {
                     max_yearpublished = d1[1].getUTCFullYear();    
                 }
 
-                // Update the select filters in the UI.
-                $('#min_year').val(d1[0].getUTCFullYear());
-                $('#max_year').val(d1[1].getUTCFullYear());
+                // update the select filters
+                const minYear = d1[0].getUTCFullYear();
+                const maxYear = d1[1].getUTCFullYear();
+                $('#min_year').val(minYear);
+                $('#max_year').val(maxYear);
+                // disable options that are not available
+                updateYearDropdowns(minYear, maxYear);
 
                 app.map.pullDataAndUpdate();
             } 


### PR DESCRIPTION
Addressing Sam's comment [here](https://simonsfoundation.atlassian.net/browse/TTWWW-469?focusedCommentId=111722)

I went the route of disabling options that we don't want selectable (min year greater than the max year, max year less than min year). This was a more straight forward approach compared to removing and re-adding the options as needed, and felt like a better user experience to me so that you always know what years are available. I left a comment to Sam on the task letting him know I went this direction, so he can let us know if he wants them to be removed.

- [x] pull this branch
- [x] compile JS updates
- [x] select an earliest year published and confirm that the options less than that in the max year published are disabled
- [x] refresh the page and confirm these options stay disabled
- [x] click 'clear' and confirm these disabled options reset
- [x] select a latest year published and confirm that the options greater than that in the min year published are disabled