### PR TITLE
TTWWW-573: Updates to allow map filters to stay active when navigating to the about page and back

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -96,6 +96,7 @@ export function ttInitJoint() {
             $('#list-link').attr('href', '/list/' + app.api_call_param_string);
             $('#map-link').attr('href', '/' + app.api_call_param_string);
             $('#download-link').attr('href', '/studies-csv/' + app.api_call_param_string);
+            $('#about-link').attr('href', '/about/' + app.api_call_param_string);
         }
 
         // function for updating content based on filters
@@ -716,26 +717,28 @@ export function ttInitJoint() {
         const searchInput = document.querySelector('[data-id="keyword-filter-input"]') as HTMLInputElement;
         const xButton = document.querySelector('[data-id="keyword-filter-x-btn"]') as HTMLButtonElement;
 
-        function toggleXButton() {
-            if (searchInput.value.trim().length > 0) {
-                xButton.classList.remove('hidden');
-            } else {
-                xButton.classList.add('hidden');
+        if (searchInput) {
+            function toggleXButton() {
+                if (searchInput.value.trim().length > 0) {
+                    xButton.classList.remove('hidden');
+                } else {
+                    xButton.classList.add('hidden');
+                }
             }
-        }
 
-        searchInput.addEventListener('input', toggleXButton);
-        toggleXButton();
-
-        // when the X button is clicked, clear the search, remove the keyword
-        xButton.addEventListener('click', function () {
-            searchInput.value = '';
-            // reset the global 'keyword' variable so it's removed from URL params
-            keyword = '';
+            searchInput.addEventListener('input', toggleXButton);
             toggleXButton();
-            searchInput.focus();
-            app.runUpdate();
-        });
+
+            // when the X button is clicked, clear the search, remove the keyword
+            xButton.addEventListener('click', function () {
+                searchInput.value = '';
+                // reset the global 'keyword' variable so it's removed from URL params
+                keyword = '';
+                toggleXButton();
+                searchInput.focus();
+                app.runUpdate();
+            });
+        }
 
         // update min and max year labels based on the timeline study type
         if (timeline_type == 'studied') {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/main.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/main.ts
@@ -17,8 +17,8 @@ import { ttInitList } from './list.ts';
             ttInitArray();
             ttInitGeo();
             ttInitProjection();
-            ttInitJoint();
         }
+        ttInitJoint();
         ttInitMobilePopup();
 
         switch (pageName) {

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/about.html
@@ -116,3 +116,25 @@
 
 {% block modal_block %}
 {% endblock %}
+
+{% block js_block %}
+<script>
+    let min_yearpublished = '{{ min_yearpublished }}';
+    let max_yearpublished = '{{ max_yearpublished }}';
+    let yearsstudied_number_min = '{{ yearsstudied_number_min }}';
+    let yearsstudied_number_max = '{{ yearsstudied_number_max }}';
+    let min_samplesize = '{{ min_samplesize }}';
+    let max_samplesize = '{{ max_samplesize }}';
+    let min_prevalenceper10000 = '{{ min_prevalenceper10000 }}';
+    let max_prevalenceper10000 = '{{ max_prevalenceper10000 }}';
+    let meanincomeofparticipants = '{{ meanincomeofparticipants }}';
+    let educationlevelofparticipants = '{{ educationlevelofparticipants }}';
+    let studytype = '{{ studytype }}';
+    let keyword = '{{ keyword }}';
+    let timeline_type = '{{ timeline_type }}';
+    let income = '{{ meanincome }}';
+    let education = '{{ education }}';
+    let country = '{{ country }}';
+    let continent = '{{ continent }}';
+</script>
+{% endblock %}

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
@@ -73,7 +73,7 @@
                 <nav class='flex items-center gap-8'>
                     <a id='map-link' class='text-2xs font-bold text-navy uppercase no-underline hover:text-red {% if request.path == "/" %}text-red{% endif %}' href="{% url 'index' %}">Map</a>
                     <a id='list-link' class='text-2xs font-bold text-navy uppercase no-underline hover:text-red {% if request.path == "/list/" %}text-red{% endif %}' href="{% url 'list_view' %}">List</a>
-                    <a class='text-2xs font-bold text-navy uppercase no-underline hover:text-red {% if request.path == "/about/" %}text-red{% endif %}' href="{% url 'about' %}">About</a>
+                    <a id='about-link' class='text-2xs font-bold text-navy uppercase no-underline hover:text-red {% if request.path == "/about/" %}text-red{% endif %}' href="{% url 'about' %}">About</a>
                 </nav>
 
                 {% if request.path != "/about/" %}

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -325,10 +325,43 @@ def about(request):
     else :
         style_sheet = 'autism_prevalence_map/dist/main.min.css'
         script = 'autism_prevalence_map/dist/main.min.js'
+
+    if request.method == 'GET':
+        min_yearpublished = request.GET.get('min_yearpublished','')
+        max_yearpublished = request.GET.get('max_yearpublished','')
+        yearsstudied_number_min = request.GET.get('yearsstudied_number_min','')
+        yearsstudied_number_max = request.GET.get('yearsstudied_number_max','')
+        min_samplesize = request.GET.get('min_samplesize','')
+        max_samplesize = request.GET.get('max_samplesize','')
+        min_prevalenceper10000 = request.GET.get('min_prevalenceper10000','')
+        max_prevalenceper10000 = request.GET.get('max_prevalenceper10000','')
+        studytype = request.GET.get('studytype','')
+        keyword = request.GET.get('keyword','')
+        timeline_type = request.GET.get('timeline_type','published')
+        meanincome = request.GET.get('meanincome','')
+        education = request.GET.get('education','')
+        country = request.GET.get('country', '')
+        continent = request.GET.get('continent', '')
+
     context_dict = {
+        'min_yearpublished':min_yearpublished,
+        'max_yearpublished':max_yearpublished,
+        'yearsstudied_number_min':yearsstudied_number_min,
+        'yearsstudied_number_max':yearsstudied_number_max,
+        'min_samplesize':min_samplesize,
+        'max_samplesize':max_samplesize,
+        'min_prevalenceper10000':min_prevalenceper10000,
+        'max_prevalenceper10000':max_prevalenceper10000,
+        'studytype':studytype,
+        'keyword':keyword,
+        'timeline_type':timeline_type,
+        'meanincome':meanincome,
+        'education':education,
+        'country': country,
+        'continent': continent,
         'style_sheet': style_sheet,
-        'script': script,
-    }
+        'script': script,}
+        
     return render(request, 'autism_prevalence_map/about.html', context_dict)
 
 def studiesApi(request):


### PR DESCRIPTION
This is addressing Sam's comment [here](https://simonsfoundation.atlassian.net/browse/TTWWW-573?focusedCommentId=111634). The comment was focused on the static mean box, but the real issue was that the filters would not persist when navigating to the about page and then back to the map or list page. So I made the joint.ts file be included on the about page, and then modified views.py and the about page to make sure that filter data was available on the about page.

- [x] check out this branch
- [x] compile JS updates
- [x] From the map or list page, use the filters to narrow down results, and click the calculate mean button, then click the about page link. Verify that the query parameters in the URL have not been updated or removed
- [x] from the about page, use the navigation to navigate to the map or list page. Confirm that the filters are still what you set them to before, and that the static mean box is still visible and contains the correct value