### PR TITLE
TTWWW-475: updated to use UTC time and make more consistent

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/joint.ts
@@ -96,6 +96,7 @@ export function ttInitJoint() {
             $('#list-link').attr('href', '/list/' + app.api_call_param_string);
             $('#map-link').attr('href', '/' + app.api_call_param_string);
             $('#download-link').attr('href', '/studies-csv/' + app.api_call_param_string);
+            $('#about-link').attr('href', '/about/' + app.api_call_param_string);
         }
 
         // function for updating content based on filters
@@ -239,8 +240,7 @@ export function ttInitJoint() {
             const minYearSelected = parseInt($(this).val());
             const maxYearSelected = parseInt($('#max_year').val());
             updateYearDropdowns(minYearSelected, maxYearSelected);
-            let selection = d3.select('.selection');
-            if (!selection.empty() && selection.attr('display') !== 'none') {
+            if (app.map && typeof app.map.updateTimelineBrushFromFilters === 'function') {
                 app.map.updateTimelineBrushFromFilters();
             }
             app.runUpdate();
@@ -257,8 +257,7 @@ export function ttInitJoint() {
             const maxYearSelected = parseInt($(this).val());
             const minYearSelected = parseInt($('#min_year').val());
             updateYearDropdowns(minYearSelected, maxYearSelected);
-            let selection = d3.select('.selection');
-            if (!selection.empty() && selection.attr('display') !== 'none') {
+            if (app.map && typeof app.map.updateTimelineBrushFromFilters === 'function') {
                 app.map.updateTimelineBrushFromFilters();
             }
             app.runUpdate();
@@ -716,26 +715,28 @@ export function ttInitJoint() {
         const searchInput = document.querySelector('[data-id="keyword-filter-input"]') as HTMLInputElement;
         const xButton = document.querySelector('[data-id="keyword-filter-x-btn"]') as HTMLButtonElement;
 
-        function toggleXButton() {
-            if (searchInput.value.trim().length > 0) {
-                xButton.classList.remove('hidden');
-            } else {
-                xButton.classList.add('hidden');
+        if (searchInput) {
+            function toggleXButton() {
+                if (searchInput.value.trim().length > 0) {
+                    xButton.classList.remove('hidden');
+                } else {
+                    xButton.classList.add('hidden');
+                }
             }
-        }
 
-        searchInput.addEventListener('input', toggleXButton);
-        toggleXButton();
-
-        // when the X button is clicked, clear the search, remove the keyword
-        xButton.addEventListener('click', function () {
-            searchInput.value = '';
-            // reset the global 'keyword' variable so it's removed from URL params
-            keyword = '';
+            searchInput.addEventListener('input', toggleXButton);
             toggleXButton();
-            searchInput.focus();
-            app.runUpdate();
-        });
+
+            // when the X button is clicked, clear the search, remove the keyword
+            xButton.addEventListener('click', function () {
+                searchInput.value = '';
+                // reset the global 'keyword' variable so it's removed from URL params
+                keyword = '';
+                toggleXButton();
+                searchInput.focus();
+                app.runUpdate();
+            });
+        }
 
         // update min and max year labels based on the timeline study type
         if (timeline_type == 'studied') {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -175,11 +175,19 @@ export function ttInitMap() {
         }
 
         app.map.addTimeline = function() {
-            timeMin = d3.min(studies.features, function(d) { return new Date(d.properties.yearsstudied_number_min); });
-            timeMax = d3.max(studies.features, function(d) { return new Date(d.properties.yearpublished); });
+            timeMin = d3.min(studies.features, function(d) {
+                // fallback for null values
+                const dateStr = d.properties.yearsstudied_number_min || '1970-01-01';
+                const [year] = dateStr.split('-');
+                // january 1st of the min year
+                return new Date(Date.UTC(parseInt(year, 10), 0, 1));
+            });
+            timeMax = d3.max(studies.features, function(d) {
+                const year = parseInt(d.properties.yearpublished, 10);
+                // december 31st 11:59 of the max year
+                return new Date(Date.UTC(year, 11, 31, 23, 59, 59));
+            });
 
-            // extend the timeline to the end of the year of the last available data to allow that year to be selected
-            timeMax = new Date(timeMax.getFullYear() + 1, 11, 31, 23, 59, 59);
 
             // add the x brush
             brush = d3.brushX()

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -188,7 +188,6 @@ export function ttInitMap() {
                 return new Date(Date.UTC(year, 11, 31, 23, 59, 59));
             });
 
-
             // add the x brush
             brush = d3.brushX()
                 .extent([[0, 0], [timelineWidth, timelineHeight-33]])
@@ -393,8 +392,20 @@ export function ttInitMap() {
             }
 
             max_Y_domain = d3.max(studiesByYear, function(d) { return d.value; }) + 1;
+            // dot height and the ideal gap height when we don't have to overlap dots to fit
+            const dotHeight = 8;
+            const gap = 1;
+            const dotSpacing = dotHeight + gap;
+            // max height we have to work with so we don't get too close to the help tip text line
+            const maxHeight = timelineHeight - 83;
+            // max amount of dots with ideal spacing that can fit in the max height
+            const maxDotsAtDotSpacing = Math.floor(maxHeight / dotSpacing);
+            // apply consistent offset to all years and align to the bottom
+            const offset = max_Y_domain <= maxDotsAtDotSpacing ? dotSpacing : maxHeight / (max_Y_domain - 1);
             timelineY
-                .domain([1, max_Y_domain]);
+                .domain([1, max_Y_domain])
+                .range([timelineHeight - 83, timelineHeight - 83 - (max_Y_domain - 1) * offset])
+                .clamp(true);
 
             // set count = 0 for each year for every year studied/published and
             // set up battleship grid in studiesByYear to mark where pills are when plotted
@@ -662,11 +673,6 @@ export function ttInitMap() {
             // only if we have a valid brush and timeline
             if (!brush || !timelineX) return;
             
-            // only update if the selection is already being used
-            if (d3.select('.selection').attr('display') === 'none' || d3.select('.selection').empty()) {
-                return;
-            }
-            
             let minYear, maxYear;
             
             if (timeline_type == 'studied') {
@@ -677,10 +683,9 @@ export function ttInitMap() {
                 maxYear = max_yearpublished || $('#max_year').val();
             }
         
-            const minDate = new Date(parseInt(minYear, 10), 0, 1);
-            const maxDate = new Date(parseInt(maxYear, 10), 11, 31, 23, 59, 59);
-            
-            if (brushG && minYear && maxYear) {
+            if (minYear && maxYear) {
+                const minDate = new Date(parseInt(minYear, 10), 0, 1);
+                const maxDate = new Date(parseInt(maxYear, 10), 11, 31, 23, 59, 59);
                 brushG.call(brush.move, [minDate, maxDate].map(timelineX));
             }
         };


### PR DESCRIPTION
Addressing your comment here: "But I think it is a hack to tackle the symptom instead of the root cause.
I dug into the code a bit, and seemed to me the issue has to do with the timezone difference when a date string like '2010-01-01' and when this is in New York Eastern Time zone, it will get the date for Dec. 31, 2009.
The timeMin get date from yearsstudied_number_min, which as the above mentioned format, and timeMax get date from yearpublished and it only has format like '2010'. When you have time, can you please see if you can fix the root cause."

You were correct this was not the best way to handle it. I have now updated this in a better way by normalizing timeMin and timeMax to UTC. This also allowed me to remove the addition of an extra year to the timeline like I was doing before. This all works cleaner now.

- [ ] pull this branch
- [ ] compile JS updates
- [ ] drag timeline handles and confirm that all years are selectable (previous issue was you could not select 2025)