### PR TITLE
TTWWW-471: Make sure selected map dots move to the front

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -861,10 +861,12 @@ export function ttInitMap() {
             // pinned state is blue with white border
             d3.select('#map_dot_' + pk)
                 .style('fill', '#0B6BC3')
-                .style('stroke', '#FFF');
+                .style('stroke', '#FFF')
+                .moveToFront();
             d3.select('#timeline_dot_' + pk)
                 .style('fill', '#FEF9EE')
-                .style('stroke', '#FFF');
+                .style('stroke', '#FFF')
+                .moveToFront();
 
             // populate and show info card
             populateInfoCard(d);


### PR DESCRIPTION
Addressing Sam's comment [here](https://simonsfoundation.atlassian.net/browse/TTWWW-471?focusedCommentId=112218).

Selected dots on the map and the timeline now move to the front.

- [x] Pull this branch
- [x] Compile JS updates
- [x] Find a cluster of map dots where one is behind other ones, and click the dot that is behind the other ones
- [x] Confirm that the dot moves to the front on the map
- [ ] If the timeline dots are overlapping, also confirm that the timeline dot moves to the front