### PR TITLE
ttwww-581: change name of prevalence map data file download

### DIFF
--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -566,7 +566,7 @@ def studiesApi(request):
 def studiesCsv(request):
     #create header for CSV file download
     response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename="spectrum_autism_prevalence_map_data_download.csv"'
+    response['Content-Disposition'] = 'attachment; filename="transmitter_autism_prevalence_map_data_download.csv"'
 
     if request.method == 'GET':
         kwargs = {}


### PR DESCRIPTION
Jira ticket: [TTWWW-581](https://simonsfoundation.atlassian.net/browse/TTWWW-581)

To test:

- [ ] Check out this branch
- [ ] Access page 127.0.0.1:8000 and click on the download button on the top right of the page, and confirm the downloaded file name is **transmitter_autism_prevalence_map_data_download.csv**

[TTWWW-581]: https://simonsfoundation.atlassian.net/browse/TTWWW-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ