### PR TITLE
TTWWW-595: Create Cache Buster for Prev Map Deployments

### DIFF
--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -8,6 +8,7 @@ import re, csv, os
 from django.contrib.postgres.search import SearchVector, SearchQuery
 from django.db.models import Avg, FloatField
 from django.db.models.functions import Cast
+from django.conf import settings
 
 #import all apartment models and forms
 from autism_prevalence_map.models import *
@@ -220,8 +221,8 @@ def index(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css'
-        script = 'autism_prevalence_map/dist/main.min.js'
+        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
+        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished', '')
@@ -274,8 +275,8 @@ def list_view(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css'
-        script = 'autism_prevalence_map/dist/main.min.js'
+        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
+        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished','')
@@ -323,8 +324,8 @@ def about(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css'
-        script = 'autism_prevalence_map/dist/main.min.js'
+        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
+        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished','')

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -9,7 +9,6 @@ from django.contrib.postgres.search import SearchVector, SearchQuery
 from django.db.models import Avg, FloatField
 from django.db.models.functions import Cast
 from django.contrib.staticfiles.finders import find as find_static_file
-from django.conf import settings
 
 #import all apartment models and forms
 from autism_prevalence_map.models import *
@@ -212,13 +211,6 @@ country_to_continent = {
   'Tuvalu': 'Australia and Oceania',
   'Vanuatu': 'Australia and Oceania'
 }
-
-# return unix timestamp to use for cache busting
-def get_file_timestamp(static_path):
-    real_path = find_static_file(static_path)
-    if real_path and os.path.exists(real_path):
-        return str(int(os.path.getmtime(real_path)))
-    return ''
 
 # attach version to file path
 def versioned(path):

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -8,6 +8,7 @@ import re, csv, os
 from django.contrib.postgres.search import SearchVector, SearchQuery
 from django.db.models import Avg, FloatField
 from django.db.models.functions import Cast
+from django.contrib.staticfiles.finders import find as find_static_file
 from django.conf import settings
 
 #import all apartment models and forms
@@ -212,6 +213,21 @@ country_to_continent = {
   'Vanuatu': 'Australia and Oceania'
 }
 
+# return unix timestamp to use for cache busting
+def get_file_timestamp(static_path):
+    real_path = find_static_file(static_path)
+    if real_path and os.path.exists(real_path):
+        return str(int(os.path.getmtime(real_path)))
+    return ''
+
+# attach version to file path
+def versioned(path):
+    real = find_static_file(path)
+    if real and os.path.exists(real):
+        ts = int(os.path.getmtime(real))
+        return f"{path}?v={ts}"
+    return path
+
 # Create your views here.
 def index(request):
     """
@@ -221,8 +237,8 @@ def index(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
-        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
+        style_sheet = versioned('autism_prevalence_map/dist/main.min.css')
+        script = versioned('autism_prevalence_map/dist/main.min.js')
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished', '')
@@ -275,8 +291,8 @@ def list_view(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
-        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
+        style_sheet = versioned('autism_prevalence_map/dist/main.min.css')
+        script = versioned('autism_prevalence_map/dist/main.min.js')
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished','')
@@ -324,8 +340,8 @@ def about(request):
         style_sheet = 'autism_prevalence_map/dist/main.css'
         script = 'autism_prevalence_map/dist/main.js'
     else :
-        style_sheet = 'autism_prevalence_map/dist/main.min.css?v=' + settings.STATIC_VERSION
-        script = 'autism_prevalence_map/dist/main.min.js?v=' + settings.STATIC_VERSION
+        style_sheet = versioned('autism_prevalence_map/dist/main.min.css')
+        script = versioned('autism_prevalence_map/dist/main.min.js')
 
     if request.method == 'GET':
         min_yearpublished = request.GET.get('min_yearpublished','')

--- a/spectrum/spectrum/settings.py
+++ b/spectrum/spectrum/settings.py
@@ -132,7 +132,6 @@ USE_L10N = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
-STATIC_VERSION = '1.0.0'
 
 STATIC_URL = os.environ["DJANGO_STATIC_URL"]
 

--- a/spectrum/spectrum/settings.py
+++ b/spectrum/spectrum/settings.py
@@ -132,6 +132,7 @@ USE_L10N = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
+STATIC_VERSION = '1.0.0'
 
 STATIC_URL = os.environ["DJANGO_STATIC_URL"]
 


### PR DESCRIPTION
Regarding [this](https://simonsfoundation.atlassian.net/browse/TTWWW-595) Jira ticket.

There are a few routes that we could go with this. Django does have a method to create static files with hashed names, but this route is just as effective with less code. Let me know if you would like to address this a different way.

The cache/file version is updated in the settings.py file. Then I am applying that version to only the .min versions of the files, not the un-minified versions that are used locally.

For testing steps, this can only be tested as-is in production. Locally, I added the version to the un-minified versions to confirm it was working as it should be.

- [ ] merge this branch and deploy to production
- [ ] confirm that ?v=1.0.0 is being appended to main.min.css and main.min.js