### PR TITLE
TTWWW-593: Add "last updated" date to prev map code

### DIFF
--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -288,4 +288,10 @@ class StudiesAdmin(admin.ModelAdmin):
         option_obj, _ = options.objects.update_or_create(name='last_updated_on')
         option_obj.value = datetime.date.today().strftime("%-d %B %Y")
         option_obj.save()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        nowformatted = now.replace(second=0, microsecond=0)
+        nowformatted = nowformatted.isoformat(timespec='minutes')
+        meta_option_obj, _ = options.objects.update_or_create(name='last_updated_on_meta')
+        meta_option_obj.value = nowformatted
+        meta_option_obj.save()
 

--- a/spectrum/autism_prevalence_map/admin.py
+++ b/spectrum/autism_prevalence_map/admin.py
@@ -285,13 +285,11 @@ class StudiesAdmin(admin.ModelAdmin):
         study.num_yearsstudied=num_yearsstudied
         
     def last_updated_on(self):
-        option_obj, _ = options.objects.update_or_create(name='last_updated_on')
-        option_obj.value = datetime.date.today().strftime("%-d %B %Y")
-        option_obj.save()
         now = datetime.datetime.now(datetime.timezone.utc)
-        nowformatted = now.replace(second=0, microsecond=0)
-        nowformatted = nowformatted.isoformat(timespec='minutes')
+        option_obj, _ = options.objects.update_or_create(name='last_updated_on')
+        option_obj.value = now.strftime("%-d %B %Y")
+        option_obj.save()
+        nowformatted = now.replace(second=0, microsecond=0).isoformat(timespec='minutes')
         meta_option_obj, _ = options.objects.update_or_create(name='last_updated_on_meta')
         meta_option_obj.value = nowformatted
         meta_option_obj.save()
-

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/base.html
@@ -6,8 +6,8 @@
     <meta charset='utf-8'>
     <title>{% block title %}Global Autism Prevalence Map | The Transmitter{% endblock %}</title>
     <meta name='description' content='The map features a collection of studies on autism prevalence around the world. It highlights places where information is available — and places where information is missing.'>
-    {% if last_updated_on %}
-    <meta name="revised" content="{{ last_updated_on }}">
+    {% if last_updated_on_meta %}
+    <meta property="article:modified_time" content="{{ last_updated_on_meta }}">
     {% endif %}
     <meta name='author' content=''>
     <meta name='twitter:card' content='summary_large_image'>

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -242,8 +242,11 @@ def index(request):
         try:
             last_updated_on_obj = options.objects.get(name='last_updated_on')
             last_updated_on = last_updated_on_obj.value
+            last_updated_on_meta_obj = options.objects.get(name='last_updated_on_meta')
+            last_updated_on_meta = last_updated_on_meta_obj.value
         except:
             last_updated_on = ''
+            last_updated_on_meta = ''
 
     context_dict = {'min_yearpublished': min_yearpublished,
                     'max_yearpublished': max_yearpublished,
@@ -261,6 +264,7 @@ def index(request):
                     'country': country,
                     'continent': continent,
                     'last_updated_on': last_updated_on,
+                    'last_updated_on_meta': last_updated_on_meta,
                     'style_sheet': style_sheet,
                     'script': script,}
     
@@ -294,10 +298,10 @@ def list_view(request):
         country = request.GET.get('country', '')
         continent = request.GET.get('continent', '')
         try:
-            last_updated_on_obj = options.objects.get(name='last_updated_on')
-            last_updated_on = last_updated_on_obj.value
+            last_updated_on_meta_obj = options.objects.get(name='last_updated_on_meta')
+            last_updated_on_meta = last_updated_on_meta_obj.value
         except:
-            last_updated_on = ''
+            last_updated_on_meta = ''
 
     context_dict = {
         'min_yearpublished':min_yearpublished,
@@ -315,7 +319,7 @@ def list_view(request):
         'education':education,
         'country': country,
         'continent': continent,
-        'last_updated_on': last_updated_on,
+        'last_updated_on_meta': last_updated_on_meta,
         'style_sheet': style_sheet,
         'script': script,}
 
@@ -349,10 +353,10 @@ def about(request):
         country = request.GET.get('country', '')
         continent = request.GET.get('continent', '')
         try:
-            last_updated_on_obj = options.objects.get(name='last_updated_on')
-            last_updated_on = last_updated_on_obj.value
+            last_updated_on_meta_obj = options.objects.get(name='last_updated_on_meta')
+            last_updated_on_meta = last_updated_on_meta_obj.value
         except:
-            last_updated_on = ''
+            last_updated_on_meta = ''
 
     context_dict = {
         'min_yearpublished':min_yearpublished,
@@ -370,7 +374,7 @@ def about(request):
         'education':education,
         'country': country,
         'continent': continent,
-        'last_updated_on': last_updated_on,
+        'last_updated_on_meta': last_updated_on_meta,
         'style_sheet': style_sheet,
         'script': script,}
         


### PR DESCRIPTION
This is an update based on Sam's comment [here](https://simonsfoundation.atlassian.net/browse/TTWWW-593?focusedCommentId=112957).

This value gets generated when something in the database gets updated. So locally I just opened a study and saved it, which generates the initial value. 

- [x] pull this branch
- [x] open the admin dashboard, open a study, and save it
- [x] view the page source or inspect element to view the meta tags in the head. Confirm the meta tag is now present and formatted as Sam requested: <meta property="article:modified_time" content="2025-04-01T03:25+00:00" />