### PR TITLE
TTWWW-473: Mega Dot update to zoom behavior

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -27,6 +27,24 @@ export function ttInitMap() {
                 .style('display', 'none')
                 .style('pointer-events', 'none')
                 .style('opacity', 1);
+
+            // reset zoom to base level (baseZoom = 1), centered on viewport
+            const newZoomLevel = baseZoom;
+            const viewportCenterX = width / 2;
+            const viewportCenterY = height / 2;
+            const translateX = viewportCenterX - viewportCenterX * newZoomLevel;
+            const translateY = viewportCenterY - viewportCenterY * newZoomLevel;
+
+            const newTransform = d3.zoomIdentity
+                .translate(translateX, translateY)
+                .scale(newZoomLevel);
+
+            svg_zoom.transition()
+                .duration(500)
+                .call(zoom.transform, newTransform);
+
+            currentZoom = newZoomLevel;
+
             app.map.drawMegadots();
         };
 


### PR DESCRIPTION
Following the comment in Jira [here](https://simonsfoundation.atlassian.net/browse/TTWWW-473?focusedCommentId=114430). This PR implements the last requirement, which is to zoom back out to the base zoom level when a user clicks to un-expand all mega dots.

- [ ] pull this branch
- [ ] compile JS updates
- [ ] start the server locally and visit the map page
- [ ] click a mega dot to expand, click another mega dot to expand and confirm that it stays zoomed in and centers on the second mega dot
- [ ] click to un-expand a mega dot, and confirm that the zoom returns to the base zoom level

