### PR TITLE
TTWWW-473: Mega Dot zoom update based on QA

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -106,7 +106,6 @@ export function ttInitMap() {
                         }
                         setTimeout(() => {
                             app.map.isAutoZoomTransition = false;
-                            console.log('expandCluster transition end: lastZoomAction =', app.map.lastZoomAction, 'isAutoZoomTransition =', app.map.isAutoZoomTransition, 'currentZoom =', currentZoom);
                         }, 200);
                     });
 


### PR DESCRIPTION
This update is to address Sam's comment h[ere](https://simonsfoundation.atlassian.net/browse/TTWWW-473?focusedCommentId=114669).

I addressed his comment, so that zooming in will reform clusters based on the zoom level and new radius. I also added an enhancment to the auto zoom in and zoom out functionality we had based on a use case that this added. I created a video showing this, but basically when dots would form into smaller clusters after zooming in, then you expanded a mega dot, then clicked a dot close to but outside of that expanded mega dot, when it zoomed back out that clicked dot would form into a larger mega dot. I updated the experience so that when the user was auto zoomed into a mega dot when it expands, clicking out of it would auto zoom back out. But if a user manually zooms in and then expands a mega dot, we would not auto zoom them back out. https://www.loom.com/share/68600605952245c58e0e55cc02ebca81?sid=fc47d7e1-f558-4ef1-916f-d1958b472b23

- [x] pull this branch
- [x] compile JS updates
- [x] click a mega dot to expand it (it should auto zoom in), then click a dot outside the mega dot which should auto zoom back out.
- [x] zoom in a few levels so that mega dots re-cluster, then click a mega dot to expand it, then click a dot outside which should close the mega dot but not auto zoom back out.