### PR TITLE
TTWWW-473: mega dot updates based on QA feedback

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -22,6 +22,11 @@ export function ttInitMap() {
         let originalWidth, originalScale;
 
         app.map.collapseCluster = function () {
+            if (pinnedDot) {
+                unpinDot(pinnedDot);
+                pinnedDot = null;
+            }
+
             app.map.expandedCluster = null;
             studiesG.selectAll('circle.map-circles')
                 .style('visibility', 'hidden')
@@ -59,6 +64,11 @@ export function ttInitMap() {
         };
 
         app.map.expandCluster = function (clusterId) {
+            if (pinnedDot) {
+                unpinDot(pinnedDot);
+                pinnedDot = null;
+            }
+
             const cluster = app.map.clusters.find(c => c.id === clusterId);
             if (cluster) {
                 app.map.expandedCluster = cluster;
@@ -114,6 +124,23 @@ export function ttInitMap() {
         };
 
         app.map.drawMegadots = function() {
+             const maxZoomThreshold = 6.5536;
+    
+            // if zoomed in beyond the threshold, don't draw any mega dots
+            if (currentZoom >= maxZoomThreshold) {
+                studiesG.selectAll('.megadot-container').remove();
+                
+                nodes.forEach(node => {
+                    d3.select('#map_dot_' + node.properties.pk)
+                        .style('visibility', 'visible')
+                        .style('display', null)
+                        .style('pointer-events', 'auto')
+                        .style('opacity', 1);
+                });
+                
+                return;
+            }
+
             studiesG.selectAll('.megadot-container').remove();
             app.map.clusters.forEach(cluster => {
                 // size of collapsed circle
@@ -238,6 +265,25 @@ export function ttInitMap() {
 
         app.map.createMegadots = function() {
             if (!nodes || nodes.length === 0) return;
+
+            const maxZoomThreshold = 6.5536;
+    
+            // if zoomed in beyond the threshold, show all individual dots and skip mega dots
+            if (currentZoom >= maxZoomThreshold) {
+                studiesG.selectAll('circle.map-circles')
+                    .style('visibility', 'visible')
+                    .style('display', null)
+                    .style('pointer-events', 'auto')
+                    .style('opacity', 1);
+                    
+                studiesG.selectAll('.megadot-container').remove();
+                
+                const previousExpandedClusterId = app.map.expandedCluster ? app.map.expandedCluster.id : null;
+                app.map.expandedCluster = null;
+                
+                return;
+            }
+
             const previousExpandedClusterId = app.map.expandedCluster ? app.map.expandedCluster.id : null;
 
             studiesG.selectAll('circle.map-circles')

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -126,7 +126,7 @@ export function ttInitMap() {
         app.map.drawMegadots = function() {
              const maxZoomThreshold = 6.5536;
     
-            // if zoomed in beyond the threshold, don't draw any mega dots
+            // if zoomed in to the threshold, don't draw any mega dots
             if (currentZoom >= maxZoomThreshold) {
                 studiesG.selectAll('.megadot-container').remove();
                 
@@ -268,7 +268,7 @@ export function ttInitMap() {
 
             const maxZoomThreshold = 6.5536;
     
-            // if zoomed in beyond the threshold, show all individual dots and skip mega dots
+            // if zoomed in to the threshold, don't draw any mega dots
             if (currentZoom >= maxZoomThreshold) {
                 studiesG.selectAll('circle.map-circles')
                     .style('visibility', 'visible')


### PR DESCRIPTION
These updates were to address Sam's comments [here](https://simonsfoundation.atlassian.net/browse/TTWWW-473?focusedCommentId=115168).

- [x] pull this branch
- [x] compile JS udpates
- [x] click a single map dot to show the info card, then click a mega dot to expand it. Confirm that the info window closes/returns to the welcome window
- [x] click a mega dot to expand it, then click a single map dot inside of that expanded mega dot, then click outside of the mega dot to collapse it. Confirm that the info window that showed when you clicked the map dot in the mega dot now closes/returns to the welcome window
- [x] zoom all the way into the map, confirm that at the max zoom the mega dots go away and you see only individual map dots
- [x] when zoomed all the way in on the map, zoom out and confirm that the mega dots re-form