### PR TITLE
TTWWW-473: Map zoom update based on QA feedback

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/map.ts
@@ -127,7 +127,7 @@ export function ttInitMap() {
              const maxZoomThreshold = 6.5536;
     
             // if zoomed in to the threshold, don't draw any mega dots
-            if (currentZoom >= maxZoomThreshold) {
+            if (currentZoom >= maxZoomThreshold && !app.map.expandedCluster) {
                 studiesG.selectAll('.megadot-container').remove();
                 
                 nodes.forEach(node => {
@@ -269,7 +269,7 @@ export function ttInitMap() {
             const maxZoomThreshold = 6.5536;
     
             // if zoomed in to the threshold, don't draw any mega dots
-            if (currentZoom >= maxZoomThreshold) {
+            if (currentZoom >= maxZoomThreshold && !app.map.expandedCluster) {
                 studiesG.selectAll('circle.map-circles')
                     .style('visibility', 'visible')
                     .style('display', null)


### PR DESCRIPTION
This update is to address Sam's comment [here](https://simonsfoundation.atlassian.net/browse/TTWWW-473?focusedCommentId=115285).

- [ ] check out this branch
- [ ] compile JS updates
- [ ] click a mega dot to expand it, then zoom in to the max zoom level. Confirm that the mega dots (expanded and closed) are still shown as mega dots
- [ ] click outside of the mega dot to close it, and confirm that all mega dots now turn into individual map points
- [ ] refresh to return to the default zoom level, don't expand a mega dot, and zoom to the max zoom level. Confirm that mega dots turn into individual map dots