### PR TITLE
Revert "TTWWW-592: Hide map/other menu links from the mobile prev map About page"

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
@@ -501,9 +501,4 @@
     #studies-table .show a {
         @apply no-underline;
     }
-    @media screen and (max-width: 767px) {
-        [data-page='about'] header {
-            @apply hidden;
-        }
-    }
 }


### PR DESCRIPTION
Reverts simonsfoundation/spectrum-autism-prevalence-map#102

TT Sam requested to remove this PR from our deployment to production(mega dot mostly)