### PR TITLE
TTWWW-548: Add requirement for urllib to fix imort error cause on eb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ django-ckeditor-5==0.2.13
 Pillow==10.4.0
 requests
 django-mathfilters
+urllib3<2


### PR DESCRIPTION
Add requirement to prevent Import error for urllib on staging (EB)