### PR TITLE
Revert "Revert "TTWWW-592: Hide map/other menu links from the mobile prev map About page""

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
@@ -528,4 +528,9 @@
     #studies-table .show a {
         @apply no-underline;
     }
+    @media screen and (max-width: 767px) {
+        [data-page='about'] header {
+            @apply hidden;
+        }
+    }
 }


### PR DESCRIPTION
Reverts simonsfoundation/spectrum-autism-prevalence-map#112

This restores the changes previously reverted as requested by Sam. Comment to restore code after About page work has passed QA ([Comment](https://simonsfoundation.atlassian.net/browse/TTWWW-592?focusedCommentId=119587))