### PR TITLE
TTWWW-591: QA updates based on comments from Sam

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
@@ -208,6 +208,7 @@ module.exports = {
                 'info2': 'calc(100% - 79px)', // height of the info card minus the sticky button wrapper at the bottom with 2 links
                 'info3': 'calc(100% - 106px)', // height of the info card minus the sticky button wrapper at the bottom with 3 links
                 'info4': 'calc(100% - 133px)', // height of the info card minus the sticky button wrapper at the bottom with 4 links
+                'list-table': 'calc(100vh - 268px)', // height of the page minus the header, filters, and page padding
             },
             maxWidth: {
                 'tooltip': '11.625rem', // 186px

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
@@ -531,21 +531,21 @@
     #studies-table tbody td {
         @apply bg-tan;
     }
-    #studies-table_tbody tr:not(.collapsed):not(.bg-tan) {
+    #studies-table tbody tr:not(.collapsed):not(.bg-tan) {
         @apply border-med-navy;
     }
-    #studies-table_tbody tr:not(.collapsed):not(.bg-tan) td,
-    #studies-table_tbody tr:not(.collapsed):not(.bg-tan) th {
+    #studies-table tbody tr:not(.collapsed):not(.bg-tan) td,
+    #studies-table tbody tr:not(.collapsed):not(.bg-tan) th {
         @apply bg-white2;
     }
-    #studies-table_tbody tr:not(.collapsed):not(.bg-tan) .chevron-down {
+    #studies-table tbody tr:not(.collapsed):not(.bg-tan) .chevron-down {
         @apply rotate-180;
     }
-    #studies-table_tbody tr.show {
+    #studies-table tbody tr.show {
         @apply border-light-gray2 border-b-0.3125;
     }
-    #studies-table_tbody tr.show td,
-    #studies-table_tbody tr.show .min-w-toggle {
+    #studies-table tbody tr.show td,
+    #studies-table tbody tr.show .min-w-toggle {
         @apply pt-6 pb-10.5;
     }
     #studies-table .show {

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
@@ -216,8 +216,8 @@
                                         </span>
                                     </div>
                                     <div class='absolute hidden top-8.75 -right-4.5 px-4.5 py-2.25 z-10 bg-light-navy-2 rounded-sm shadow-tooltip' data-id='sort-pop'data-sort-field='yearsstudied'>
-                                        <button type='button' data-sort-order='asc' class='block text-2xs text-dark-gray2 font-normal leading-6.25 uppercase no-underline cursor-pointer'>Numerically (Ascending)</button>
-                                        <button type='button' data-sort-order='desc' class='block text-2xs text-dark-gray2 font-normal leading-6.25 uppercase no-underline cursor-pointer'>Numerically (Descending)</button>
+                                        <button type='button' data-sort-order='asc' class='block pr-9 text-2xs text-dark-gray2 font-normal leading-6.25 uppercase no-underline cursor-pointer'>Earliest</button>
+                                        <button type='button' data-sort-order='desc' class='block pr-9 text-2xs text-dark-gray2 font-normal leading-6.25 uppercase no-underline cursor-pointer'>Latest</button>
                                     </div>
                                 </div>
                             </th>

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
@@ -17,9 +17,9 @@
     {% include "autism_prevalence_map/action_buttons.html" with template="list" %}
 
     <div class='pt-3.25 pb-4 mx-auto max-w-container'>
-        <div id='list'>
+        <div class='relative' id='list'>
             <div class='pb-3.25 text-2xs uppercase text-med-navy'><span id='results-count'>0</span> results</div>
-            <div class='w-full overflow-x-auto' data-id='scroll-wrapper'>
+            <div class='relative w-full max-h-list-table overflow-auto' data-id='scroll-wrapper'>
                 <table id='studies-table' class='table-fixed'>
                     <!-- <thead class='bg-dark-gray border-b-3 border-tan sticky top-17.7 z-10'> -->
                     <thead class='relative border-b-3 border-tan'>
@@ -112,7 +112,7 @@
                             <th scope='col'>
                                 <div class='relative inline-block' data-id='sort-wrapper'>
                                     <div class='relative flex gap-1 pt-0.75 pr-0.25 pb-0.5 pl-1.5 rounded-sm cursor-pointer hover:bg-dark-gray3 transition-colors duration-150' data-id='sort-trigger' aria-expanded='false'>
-                                        <span>95% CONFIDENCE INTERVAL</span>
+                                        <span>95% CI</span>
                                         <span class='w-chevron transition-transform duration-150' data-id='sort-chevron'>
                                             {% svg 'icon-sort' %}
                                         </span>

--- a/spectrum/autism_prevalence_map/views.py
+++ b/spectrum/autism_prevalence_map/views.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse, HttpResponse
 from datetime import date
 import re, csv, os
 from django.contrib.postgres.search import SearchVector, SearchQuery
-from django.db.models import Avg, FloatField
+from django.db.models import Avg, FloatField, F
 from django.db.models.functions import Cast
 from django.contrib.staticfiles.finders import find as find_static_file
 from autism_prevalence_map.models import *
@@ -560,6 +560,15 @@ def studiesApi(request):
             pulled_studies = studies.objects.filter(**kwargs)
 
         # column sorting on list page
+        # Numeric fields where NULL should be treated as lowest value
+        numeric_fields_with_nulls = {
+            'samplesize_number',
+            'prevalenceper10000_number',
+            'individualswithautism_number',
+            'percentwaverageiq_number',
+            'sexratiomf_number',
+        }
+
         sortable_fields = {
             'yearpublished',
             'authors',
@@ -578,15 +587,44 @@ def studiesApi(request):
             'categoryadpddorasd',
             'studytype'
         }
+
+        # Map numeric fields to their text field equivalents for tiebreaking
+        numeric_to_text_field = {
+            'samplesize_number': 'samplesize',
+            'prevalenceper10000_number': 'prevalenceper10000',
+            'individualswithautism_number': 'individualswithautism',
+            'percentwaverageiq_number': 'percentwaverageiq',
+            'sexratiomf_number': 'sexratiomf',
+        }
+
         if sort_field:
             if sort_field == 'confidenceinterval':
-                pulled_studies = (pulled_studies.order_by('confidenceinterval_low' if sort_order == 'asc' else 'confidenceinterval_high'))
-            elif sort_field == 'age':
+                # Treat NULL as lowest value, use text field as tiebreaker so empty comes before "Unavailable"
                 if sort_order == 'asc':
-                    pulled_studies = pulled_studies.order_by('age_low', 'age_high')
+                    pulled_studies = pulled_studies.order_by(F('confidenceinterval_low').asc(nulls_first=True), F('confidenceinterval').asc(nulls_first=True))
                 else:
-                    pulled_studies = pulled_studies.order_by('-age_high', '-age_low')
+                    pulled_studies = pulled_studies.order_by(F('confidenceinterval_high').desc(nulls_last=True), F('confidenceinterval').desc(nulls_last=True))
+            elif sort_field == 'age':
+                # Treat NULL as lowest value, use text field as tiebreaker so empty comes before "Unavailable"
+                if sort_order == 'asc':
+                    pulled_studies = pulled_studies.order_by(F('age_low').asc(nulls_first=True), F('age_high').asc(nulls_first=True), F('age').asc(nulls_first=True))
+                else:
+                    pulled_studies = pulled_studies.order_by(F('age_high').desc(nulls_last=True), F('age_low').desc(nulls_last=True), F('age').desc(nulls_last=True))
+            elif sort_field == 'yearsstudied':
+                # Treat NULL as lowest value, use text field as tiebreaker so empty comes before "Unavailable"
+                if sort_order == 'asc':
+                    pulled_studies = pulled_studies.order_by(F('yearsstudied_number_min').asc(nulls_first=True), F('yearsstudied').asc(nulls_first=True))
+                else:
+                    pulled_studies = pulled_studies.order_by(F('yearsstudied_number_max').desc(nulls_last=True), F('yearsstudied').desc(nulls_last=True))
+            elif sort_field in numeric_fields_with_nulls:
+                # Treat NULL as lowest value, use text field as tiebreaker so empty comes before "Unavailable"
+                text_field = numeric_to_text_field.get(sort_field)
+                if sort_order == 'asc':
+                    pulled_studies = pulled_studies.order_by(F(sort_field).asc(nulls_first=True), F(text_field).asc(nulls_first=True))
+                else:
+                    pulled_studies = pulled_studies.order_by(F(sort_field).desc(nulls_last=True), F(text_field).desc(nulls_last=True))
             elif sort_field in sortable_fields:
+                # For text fields, use standard ordering
                 prefix = '' if sort_order == 'asc' else '-'
                 pulled_studies = pulled_studies.order_by(prefix + sort_field)
 


### PR DESCRIPTION
Addressing the comments from Sam [here](https://simonsfoundation.atlassian.net/browse/TTWWW-589). This currently is only addressing the comments on 589 and not yet on 591. I will create a new PR to address comments regarding 591. 

1. This fixes the bug where the list row was no longer turning white, and the chevron no longer rotating when a row was expanded
2. This adds a fixed height to the list table so that we have visible horizontal scroll bars when the user scrolls horizontally.
3. Updated the label for Confidence Interval to CI

As discussed, did not add the right side gradient to the table.

UPDATE:
Also addressed the QA comments from Sam regarding TTWWW-591 [here](https://simonsfoundation.atlassian.net/browse/TTWWW-591?focusedCommentId=124647). 

1. set “unavailable” to the lowest value in columns that are sorted by ascending/descending values, rather than the highest.
2. updated sorting options on “years studied” to read “earliest” and “latest” instead of “ascending” and “descending”

To test:
- [x] pull this branch
- [x] compile CSS and JS updates
- [x] on the list page, expand a row by clicking it, confirm that the clicked row turns white, gets a darker bottom border, and the chevron rotates
- [x] on the list page, confirm that there is now visible horizontal scroll bar when scrolling horizontally
- [x] confirm the 95% CONFIDENCE INTERVAL column header has been updated to 95% CI
- [x] find a column that contains "Unavailable" values. Click to sort by ascending and confirm that "Unavailable" now appears as the lowest values
- [x] click the icon to sort "Years Studied" and confirm that the labels now read "earliest" and "latest"

