### PR TITLE
TTWWW-664: Add opacity to right side of prevalence map "list" view

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind.config.js
@@ -168,6 +168,7 @@ module.exports = {
                 'arrow2': '0.813rem', // 13px
                 'switchin': '0.875rem', // 14px
                 'chevron': '1.25rem', // 20px
+                'gradient': '7.5rem', // 120px
                 'zoomcontrol': '2.25rem', // 36px
                 'switchout': '2.75rem', // 44px
                 'filter': '10.813rem', // 173px
@@ -268,6 +269,7 @@ module.exports = {
                 '23': '5.75rem', // 92px
                 '24' : '6rem', // 96px
                 '25.5' : '6.375rem', // 102px
+                '30' : '7.5rem', // 120px
                 '38.75' : '9.6875rem', // 155px
                 '46.5' : '11.625rem', // 186px
                 '62' : '15.5rem', // 248px

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
@@ -518,10 +518,10 @@
         @apply pr-14 pl-1.5;
     }
     #studies-table th:not(.min-w-toggle):last-child {
-        @apply pr-6.5;
+        @apply pr-30;
     }
     #studies-table td:last-child {
-        @apply pr-0;
+        @apply pr-30;
     }
     #studies-table td,
     #studies-table .min-w-toggle {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -465,7 +465,54 @@ export function ttInitList() {
             $(this).find('.chevron-down').toggleClass('open');
         });
 
-        // initialize
+        // gradient fade effect on table right edge
+        function updateTableGradient() {
+            const scrollWrapper = $('[data-id="scroll-wrapper"]')[0];
+            const gradient = $('#table-fade-gradient')[0];
+            const table = $('#studies-table')[0];
+
+            if (!scrollWrapper || !gradient || !table) return;
+
+            const wrapperRect = scrollWrapper.getBoundingClientRect();
+            const tableRect = table.getBoundingClientRect();
+            const listRect = $('#list')[0].getBoundingClientRect();
+
+            // calculate where the table starts within the visible scroll wrapper viewport
+            const tableTopInWrapper = tableRect.top - wrapperRect.top;
+
+            // 71px matches the table header
+            const darkGradientHeight = 71;
+            const darkGradientBottom = tableTopInWrapper + darkGradientHeight;
+            const clampedDarkBottom = Math.max(0, darkGradientBottom);
+
+            // position gradient to match the scroll wrapper's visible area (relative to #list container)
+            const gradientTop = wrapperRect.top - listRect.top;
+            gradient.style.top = `${gradientTop}px`;
+            gradient.style.height = `${wrapperRect.height}px`;
+
+            const gradientBg = `
+                linear-gradient(to right,
+                    rgba(45, 45, 45, 0) 0%,
+                    rgba(45, 45, 45, 0.95) 100%
+                ),
+                linear-gradient(to right,
+                    rgba(254, 249, 238, 0) 0%,
+                    rgba(254, 249, 238, 0.95) 100%
+                )
+            `;
+
+            gradient.style.background = gradientBg;
+            gradient.style.backgroundSize = `100% ${clampedDarkBottom}px, 100% 100%`;
+            gradient.style.backgroundPosition = `0 0, 0 ${clampedDarkBottom}px`;
+            gradient.style.backgroundRepeat = 'no-repeat';
+        }
+
+        $('[data-id="scroll-wrapper"]').on('scroll', updateTableGradient);
+
+        $(window).on('resize', updateTableGradient);
+
+        setTimeout(updateTableGradient, 100);
+
         app.list.loadWorldMap();
     });
 }

--- a/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
+++ b/spectrum/autism_prevalence_map/templates/autism_prevalence_map/list.html
@@ -19,6 +19,7 @@
     <div class='pt-3.25 pb-4 mx-auto max-w-container'>
         <div class='relative' id='list'>
             <div class='pb-3.25 text-2xs uppercase text-med-navy'><span id='results-count'>0</span> results</div>
+            <div id='table-fade-gradient' class='absolute right-0 w-gradient pointer-events-none z-20'></div>
             <div class='relative w-full max-h-list-table overflow-auto' data-id='scroll-wrapper'>
                 <table id='studies-table' class='table-fixed'>
                     <!-- <thead class='bg-dark-gray border-b-3 border-tan sticky top-17.7 z-10'> -->


### PR DESCRIPTION
This PR addresses [this Jira ticket](https://simonsfoundation.atlassian.net/browse/TTWWW-664).

With this PR I was able to get a gradient to work on the right side of the List view table that stays in place when scrolling horizontally and scrolls with the table when scrolling vertically.

To Test
- [x] pull this branch
- [x] compile CSS and JS changes
- [x] visit the List page and confirm there is a gradient on the right side of the table
- [x] confirm that the gradient stays where it should when scrolling vertically and horizontally