### PR TITLE
TTWWW-664: updated the list gradient to fade out at the end of the table

### DIFF
--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/tailwind/tailwind.css
@@ -518,10 +518,10 @@
         @apply pr-14 pl-1.5;
     }
     #studies-table th:not(.min-w-toggle):last-child {
-        @apply pr-75;
+        @apply pr-6.5;
     }
     #studies-table td:last-child {
-        @apply pr-75;
+        @apply pr-6.5;
     }
     #studies-table td,
     #studies-table .min-w-toggle {

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -483,7 +483,7 @@ export function ttInitList() {
             const clientWidth = scrollWrapper.clientWidth;
             const distanceFromRight = scrollWidth - scrollLeft - clientWidth;
 
-            // dade out the gradient when within 300px of the right edge
+            // fade out the gradient when within 300px of the right edge
             let gradientOpacity = 1;
             if (distanceFromRight < 300) {
                 gradientOpacity = distanceFromRight / 300;

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -477,6 +477,18 @@ export function ttInitList() {
             const tableRect = table.getBoundingClientRect();
             const listRect = $('#list')[0].getBoundingClientRect();
 
+            // Calculate how far we are from the right edge of the table
+            const scrollLeft = scrollWrapper.scrollLeft;
+            const scrollWidth = scrollWrapper.scrollWidth;
+            const clientWidth = scrollWrapper.clientWidth;
+            const distanceFromRight = scrollWidth - scrollLeft - clientWidth;
+
+            // Fade out the gradient when within 300px of the right edge
+            let gradientOpacity = 1;
+            if (distanceFromRight < 300) {
+                gradientOpacity = distanceFromRight / 300;
+            }
+
             // calculate where the table starts within the visible scroll wrapper viewport
             const tableTopInWrapper = tableRect.top - wrapperRect.top;
 
@@ -489,15 +501,16 @@ export function ttInitList() {
             const gradientTop = wrapperRect.top - listRect.top;
             gradient.style.top = `${gradientTop}px`;
             gradient.style.height = `${wrapperRect.height}px`;
+            gradient.style.opacity = gradientOpacity.toString();
 
             const gradientBg = `
                 linear-gradient(to right,
                     rgba(45, 45, 45, 0) 0%,
-                    rgba(45, 45, 45, 0.95) 90%
+                    rgba(45, 45, 45, 0.95) 100%
                 ),
                 linear-gradient(to right,
                     rgba(254, 249, 238, 0) 0%,
-                    rgba(254, 249, 238, 0.95) 90%
+                    rgba(254, 249, 238, 0.95) 100%
                 )
             `;
 

--- a/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
+++ b/spectrum/autism_prevalence_map/static/autism_prevalence_map/ts/list.ts
@@ -477,13 +477,13 @@ export function ttInitList() {
             const tableRect = table.getBoundingClientRect();
             const listRect = $('#list')[0].getBoundingClientRect();
 
-            // Calculate how far we are from the right edge of the table
+            // how far we are from the right edge of the table
             const scrollLeft = scrollWrapper.scrollLeft;
             const scrollWidth = scrollWrapper.scrollWidth;
             const clientWidth = scrollWrapper.clientWidth;
             const distanceFromRight = scrollWidth - scrollLeft - clientWidth;
 
-            // Fade out the gradient when within 300px of the right edge
+            // dade out the gradient when within 300px of the right edge
             let gradientOpacity = 1;
             if (distanceFromRight < 300) {
                 gradientOpacity = distanceFromRight / 300;
@@ -506,11 +506,11 @@ export function ttInitList() {
             const gradientBg = `
                 linear-gradient(to right,
                     rgba(45, 45, 45, 0) 0%,
-                    rgba(45, 45, 45, 0.95) 100%
+                    rgba(45, 45, 45, 0.95) 90%
                 ),
                 linear-gradient(to right,
                     rgba(254, 249, 238, 0) 0%,
-                    rgba(254, 249, 238, 0.95) 100%
+                    rgba(254, 249, 238, 0.95) 90%
                 )
             `;
 


### PR DESCRIPTION
To address [Sam's comment here](https://simonsfoundation.atlassian.net/browse/TTWWW-664?focusedCommentId=125968), I removed the extra padding on the last column of the list table, and instead used JS to fade the gradient away when that column comes into view. Now that extra padding is not needed.